### PR TITLE
Tile annotations

### DIFF
--- a/src/annotations.py
+++ b/src/annotations.py
@@ -235,7 +235,7 @@ class Keypoint:
 
     def __init__(self, keypoint: Point, bounding_box: BoundingBox):
         """Overrides the default constructor from dataclass to validate the parameters before constructing."""
-        Keypoint.validate_keypoint(keypoint, bounding_box)
+        Keypoint.validate_keypoint(bounding_box, keypoint)
         self.keypoint = keypoint
         self.bounding_box = bounding_box
 

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -176,4 +176,15 @@ def tile_annotations(
 
 def get_annotations_in_tile(annotations: List, tile: Tuple[int]) -> List:
     """ """
-    pass
+    annotation_in_tile = lambda ann, tile: all(
+        [
+            ann.box[0] >= tile[0],
+            ann.box[1] >= tile[1],
+            ann.box[2] <= tile[2],
+            ann.box[3] <= tile[3],
+        ]
+    )
+    annotations_in_tile: List = list(
+        filter(lambda ann: annotation_in_tile(ann, tile), annotations)
+    )
+    return annotations_in_tile

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -172,3 +172,8 @@ def tile_annotations(
         for tc_list in tile_coordinates
     ]
     return annotation_tiles
+
+
+def get_annotations_in_tile(annotations: List, tile: Tuple[int]) -> List:
+    """ """
+    pass

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -134,10 +134,31 @@ def tile_annotations(
     image_height: int,
     slice_width: int,
     slice_height: int,
-    horizontal_overlap_ratio: int,
-    vertical_overlap_ratio: int,
+    horizontal_overlap_ratio: float,
+    vertical_overlap_ratio: float,
 ):
-    """ """
+    """Tiles image annotations based on a specified grid pattern with overlap.
+
+    This function takes a list of annotations (any annotation that implements the 'box' property)
+    representing objects within an image, and divides the image into a grid of tiles
+    with a specified size and overlap. It then assigns each annotation to the tile(s)
+    based on whether the annotation fully fits into the tile.
+
+    Args:
+        `annotations` (List): A list of annotations (anything that implements the 'box' property).
+        `image_width` (int): The width of the image in pixels.
+        `image_height` (int): The height of the image in pixels.
+        `slice_width` (int): The width of each tile in pixels.
+        `slice_height` (int): The height of each tile in pixels.
+        `horizontal_overlap_ratio` (float): The ratio (0.0 to 1.0) of the tile width that overlaps
+            horizontally between adjacent tiles.
+        `vertical_overlap_ratio` (float): The ratio (0.0 to 1.0) of the tile height that overlaps
+            vertically between adjacent tiles.
+
+    Returns:
+        A list of lists, where each sub-list represents a tile in the grid. Each tile's
+        sub-list contains the annotations that intersect fully with that specific tile.
+    """
     tile_coordinates: List[List[Tuple[int]]] = generate_tile_coordinates(
         image_width,
         image_height,

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -126,3 +126,16 @@ def generate_tile_coordinates(
         )
     ]
     return tile_coords
+
+
+def tile_annotations(
+    annotations: List,
+    image_width: int,
+    image_height: int,
+    slice_width: int,
+    slice_height: int,
+    horizontal_overlap_ratio: int,
+    vertical_overlap_ratio: int,
+):
+    """ """
+    pass

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -21,14 +21,14 @@ def tile_image(
     multiply to make exactly the image's dimensions, the image.crop method pads the image with
     black on the right and bottom sides.
 
-    Args :
-        image (PIL Image) - The image to tile.
-        slice_height (int) - The height of each slice.
-        slice_width (int) - The width of each slice.
-        horizontal_overlap_ratio (float) - The amount of left-right overlap between slices.
-        vertical_overlap_ratio (float) - The amount of top-bottom overlap between slices.
+    Args:
+        `image` (PIL Image): The image to tile.
+        `slice_height` (int): The height of each slice.
+        `slice_width` (int): The width of each slice.
+        `horizontal_overlap_ratio` (float) - The amount of left-right overlap between slices.
+        `vertical_overlap_ratio` (float) - The amount of top-bottom overlap between slices.
 
-    Returns : A list of sliced images.
+    Returns: A list of sliced images.
     """
     validate_tile_parameters(
         image,
@@ -61,12 +61,15 @@ def validate_tile_parameters(
 ) -> None:
     """Validates the parameters for the function 'tile_image'.
 
-    Args :
-        image (PIL Image) - The image to tile.
-        slice_height (int) - The height of each slice.
-        slice_width (int) - The width of each slice.
-        horizontal_overlap_ratio (float) - The amount of left-right overlap between slices.
-        vertical_overlap_ratio (float) - The amount of top-bottom overlap between slices.
+    Args:
+        `image` (PIL Image) - The image to tile.
+        `slice_height` (int) - The height of each slice.
+        `slice_width` (int) - The width of each slice.
+        `horizontal_overlap_ratio` (float) - The amount of left-right overlap between slices.
+        `vertical_overlap_ratio` (float) - The amount of top-bottom overlap between slices.
+
+    Raises:
+        ValueError: If slice_width is not within (0, image_width], slice_height not within (0, image_height), or horizontal/vertical overlap ratio not in (0, 1].
     """
     if not 0 < slice_width <= image.size[0]:
         raise ValueError(
@@ -93,18 +96,18 @@ def generate_tile_coordinates(
     slice_height: int,
     horizontal_overlap_ratio: int,
     vertical_overlap_ratio: int,
-) -> List[Tuple[int]]:
+) -> List[List[Tuple[int]]]:
     """Generates the box coordinates of the tiles for the function 'tile_image'.
 
-    Args :
-        image_width (int) - The image's width.
-        image_height (int) - The image's height.
-        slice_height (int) - The height of each slice.
-        slice_width (int) - The width of each slice.
-        horizontal_overlap_ratio (float) - The amount of left-right overlap between slices.
-        vertical_overlap_ratio (float) - The amount of top-bottom overlap between slices.
+    Args:
+        `image_width` (int): The image's width.
+        `image_height` (int): The image's height.
+        `slice_height` (int): The height of each slice.
+        `slice_width` (int): The width of each slice.
+        `horizontal_overlap_ratio` (float): The amount of left-right overlap between slices.
+        `vertical_overlap_ratio` (float): The amount of top-bottom overlap between slices.
 
-    Returns : A list of four coordinate tuples encoding the left, top, right, and bottom of each tile.
+    Returns: A 2d list of four coordinate tuples encoding the left, top, right, and bottom of each tile.
     """
     tile_coords = [
         [

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -38,7 +38,7 @@ def tile_image(
         vertical_overlap_ratio,
     )
     image_width, image_height = image.size
-    tile_coordinates: List[Tuple[int]] = generate_tile_coordinates(
+    tile_coordinates: List[Tuple[int, int, int, int]] = generate_tile_coordinates(
         image_width,
         image_height,
         slice_width,
@@ -96,7 +96,7 @@ def generate_tile_coordinates(
     slice_height: int,
     horizontal_overlap_ratio: int,
     vertical_overlap_ratio: int,
-) -> List[List[Tuple[int]]]:
+) -> List[List[Tuple[int, int, int, int]]]:
     """Generates the box coordinates of the tiles for the function 'tile_image'.
 
     Args:
@@ -109,7 +109,7 @@ def generate_tile_coordinates(
 
     Returns: A 2d list of four coordinate tuples encoding the left, top, right, and bottom of each tile.
     """
-    tile_coords = [
+    tile_coords: List[List[Tuple[int, int, int, int]]] = [
         [
             (
                 x * round(slice_width * horizontal_overlap_ratio),
@@ -159,7 +159,7 @@ def tile_annotations(
         A list of lists, where each sub-list represents a tile in the grid. Each tile's
         sub-list contains the annotations that intersect fully with that specific tile.
     """
-    tile_coordinates: List[List[Tuple[int]]] = generate_tile_coordinates(
+    tile_coordinates: List[List[Tuple[int, int, int, int]]] = generate_tile_coordinates(
         image_width,
         image_height,
         slice_width,
@@ -174,8 +174,22 @@ def tile_annotations(
     return annotation_tiles
 
 
-def get_annotations_in_tile(annotations: List, tile: Tuple[int]) -> List:
-    """ """
+def get_annotations_in_tile(annotations: List, tile: Tuple[int, int, int, int]) -> List:
+    """Filters annotations that fully intersect with a given tile.
+
+    This function takes a list of annotations (assumed to implement the 'box' property)
+    and a tile represented by its top-left and bottom-right corner coordinates `(left, top, right, bottom)`
+    as a tuple. It returns a new list containing only the annotations that have a bounding box
+    intersecting with the specified tile area.
+
+    Args:
+        `annotations`: A list of annotations (expected to implement the 'box' property).
+        `tile`: A tuple representing the tile's bounding box coordinates
+            `(left, top, right, bottom)`.
+
+    Returns:
+        A list of `BoundingBox` objects that intersect with the specified tile.
+    """
     annotation_in_tile = lambda ann, tile: all(
         [
             ann.box[0] >= tile[0],

--- a/src/tiling.py
+++ b/src/tiling.py
@@ -138,4 +138,16 @@ def tile_annotations(
     vertical_overlap_ratio: int,
 ):
     """ """
-    pass
+    tile_coordinates: List[List[Tuple[int]]] = generate_tile_coordinates(
+        image_width,
+        image_height,
+        slice_width,
+        slice_height,
+        horizontal_overlap_ratio,
+        vertical_overlap_ratio,
+    )
+    annotation_tiles = [
+        [get_annotations_in_tile(annotations, tc) for tc in tc_list]
+        for tc_list in tile_coordinates
+    ]
+    return annotation_tiles


### PR DESCRIPTION
Added the ability to tile annotations with the same parameters as tile_image.
If you supply both of these methods with the same parameters, they will match (IE: annotations[ix][jx] will contain all the annotations in tiles[ix][jx] for all ix, jx).

Later I might add the ability to include annotations that only overlap a given percentage of the tile.

Also made some small changes to documentation.