### PR TITLE
Test annotations

### DIFF
--- a/src/annotations.py
+++ b/src/annotations.py
@@ -153,12 +153,13 @@ class BoundingBox:
         """
         left, top, w, h = coco_annotation["bbox"]
         right, bottom = left + w, top + h
-        category = list(
-            filter(lambda c: c["id"] == coco_annotation["category_id"], categories)
-        )[0].get("name")
-        if category == None:
+        try:
+            category = list(
+                filter(lambda c: c["id"] == coco_annotation["category_id"], categories)
+            )[0].get("name")
+        except IndexError:
             raise ValueError(
-                f"Category {int(coco_annotation['category_id'])} not found in the id_to_category dictionary."
+                f"Category {int(coco_annotation['category_id'])} not found in the categories list."
             )
         return BoundingBox(category, left, top, right, bottom)
 

--- a/src/annotations.py
+++ b/src/annotations.py
@@ -202,12 +202,12 @@ class BoundingBox:
             )
         elif left == right:
             warnings.warn(
-                f"Degenerate rectangle detected. The box's left side equals it's right side (Left:{left}, Top:{top}, Right:{right}, Bottom:{bottom}).",
+                f"Degenerate rectangle detected. The box's left side equals its right side (Left:{left}, Top:{top}, Right:{right}, Bottom:{bottom}).",
                 UserWarning,
             )
         elif top == bottom:
             warnings.warn(
-                f"Degenerate rectangle detected. The box's left side equals it's right side (Left:{left}, Top:{top}, Right:{right}, Bottom:{bottom}).",
+                f"Degenerate rectangle detected. The box's top side equals its bottom side (Left:{left}, Top:{top}, Right:{right}, Bottom:{bottom}).",
                 UserWarning,
             )
 

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -139,6 +139,7 @@ class TestKeypoint:
         )
         assert true_kp == created_kp
 
+    # validate_keyoint
     def test_validate_keypoint_out_of_bounds_x(self):
         """Tests the validate_keypoint method where the keypoint is not within the left-right bounds."""
         # Left of box.
@@ -156,3 +157,13 @@ class TestKeypoint:
         # Below box
         with pytest.raises(ValueError):
             Keypoint(Point(1, 4), BoundingBox("Test", 0, 2, 2, 3))
+
+    # to_yolo
+    def test_to_yolo(self):
+        """Tests the to_yolo method."""
+        kp = Keypoint(Point(0.25, 0.25), BoundingBox("Test", 0, 0, 1, 1))
+        image_width = 2
+        image_height = 2
+        category_to_id = {"Test": 0}
+        yolo_str = kp.to_yolo(image_width, image_height, category_to_id)
+        assert yolo_str == "0 0.25 0.25 0.5 0.5 0.125 0.125"

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -98,3 +98,8 @@ class TestBoundingBox:
         """Tests the 'center' property."""
         bbox = BoundingBox("Test", 0, 0, 1, 1)
         assert (0.5, 0.5) == bbox.center
+
+    # Box
+    def test_box(self):
+        """Tests the 'box' property."""
+        pass

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -1,4 +1,4 @@
-""" """
+"""Tests for the annotations module."""
 
 import sys
 import os

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -126,6 +126,7 @@ class TestKeypoint:
         bbox = BoundingBox("Test", 0, 0, 1, 1)
         Keypoint(kp, bbox)
 
+    # from_yolo
     def test_from_yolo(self):
         """Tests the from_yolo constructor."""
         true_kp = Keypoint(Point(0.25, 0.25), BoundingBox("Test", 0, 0, 1, 1))
@@ -137,3 +138,21 @@ class TestKeypoint:
             yolo_line, image_width, image_height, id_to_category
         )
         assert true_kp == created_kp
+
+    def test_validate_keypoint_out_of_bounds_x(self):
+        """Tests the validate_keypoint method where the keypoint is not within the left-right bounds."""
+        # Left of box.
+        with pytest.raises(ValueError, match="not in the bounding box"):
+            Keypoint(Point(1, 1), BoundingBox("Test", 2, 0, 3, 2))
+        # Right of box.
+        with pytest.raises(ValueError, match="not in the bounding box"):
+            Keypoint(Point(4, 1), BoundingBox("Test", 2, 0, 3, 2))
+
+    def test_validate_keypoint_out_of_bounds_y(self):
+        """Tests the validate_keypoint method where the keypoint is not within the left-right bounds."""
+        # Above box
+        with pytest.raises(ValueError):
+            Keypoint(Point(1, 1), BoundingBox("Test", 0, 2, 2, 3))
+        # Below box
+        with pytest.raises(ValueError):
+            Keypoint(Point(1, 4), BoundingBox("Test", 0, 2, 2, 3))

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -121,4 +121,6 @@ class TestKeypoint:
 
     def test_init(self):
         """Tests the init function with valid parameters."""
-        pass
+        kp = Point(0.5, 0.5)
+        bbox = BoundingBox("Test", 0, 0, 1, 1)
+        Keypoint(kp, bbox)

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -96,4 +96,5 @@ class TestBoundingBox:
     # Center
     def test_center(self):
         """Tests the 'center' property."""
-        pass
+        bbox = BoundingBox("Test", 0, 0, 1, 1)
+        assert (0.5, 0.5) == bbox.center

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -19,7 +19,7 @@ class TestBoundingBox:
 
     # from_yolo
     def test_from_yolo(self):
-        """Tests the from_yolo function."""
+        """Tests the from_yolo constructor."""
         true_bbox = BoundingBox("Test", 0, 0, 1, 1)
         yolo_line = "0 0.25 0.25 0.5 0.5"
         image_width = 2
@@ -31,7 +31,7 @@ class TestBoundingBox:
         assert true_bbox == created_bbox
 
     def test_from_yolo_category_not_in_id_to_category_dict(self):
-        """Tests the from_yolo function where the supplied id is not in the id_to_category dictionary."""
+        """Tests the from_yolo constructor where the supplied id is not in the id_to_category dictionary."""
         yolo_line = "0 0.25 0.25 0.5 0.5"
         image_width = 2
         image_height = 2
@@ -40,6 +40,32 @@ class TestBoundingBox:
             ValueError, match="not found in the id_to_category dictionary"
         ):
             BoundingBox.from_yolo(yolo_line, image_width, image_height, id_to_category)
+
+    # from_coco
+    def test_from_coco(self):
+        """Tests the from_coco constructor."""
+        true_bbox = BoundingBox("Test", 0, 0, 1, 1)
+        coco_annotation = {
+            "id": 0,
+            "image_id": 0,
+            "category_id": 0,
+            "bbox": [0, 0, 1, 1],
+        }
+        categories = [{"id": 0, "name": "Test"}]
+        created_bbox = BoundingBox.from_coco(coco_annotation, categories)
+        assert true_bbox == created_bbox
+
+    def test_from_coco_category_not_found_in_(self):
+        """Tests the from_coco constructor where the supplied category is not in the list of category dictionaries."""
+        coco_annotation = {
+            "id": 0,
+            "image_id": 0,
+            "category_id": 0,
+            "bbox": [0, 0, 1, 1],
+        }
+        categories = [{"id": 1, "name": "Test"}]
+        with pytest.raises(ValueError, match="not found in the categories list"):
+            BoundingBox.from_coco(coco_annotation, categories)
 
     # validate_box_values
     def test_validate_box_values_left_greater_than_right(self):

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -103,4 +103,9 @@ class TestBoundingBox:
     def test_box(self):
         """Tests the 'box' property."""
         bbox = BoundingBox("Test", 0, 0, 1, 1)
-        assert [0, 0, 1, 1] == bbox.center
+        assert [0, 0, 1, 1] == bbox.box
+
+    # to_yolo
+    def test_to_yolo(self):
+        """Tests the to_yolo method."""
+        pass

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -114,3 +114,9 @@ class TestBoundingBox:
         category_to_id = {"Test": 0}
         yolo_str = bbox.to_yolo(image_width, image_height, category_to_id)
         assert yolo_str == "0 0.25 0.25 0.5 0.5"
+
+
+class TestKeypoint:
+    """Tests the Keypoint class."""
+
+    pass

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -6,7 +6,7 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 import pytest
-import annotations
+from annotations import BoundingBox, Keypoint, Point
 
 
 class TestBoundingBox:
@@ -14,4 +14,4 @@ class TestBoundingBox:
 
     def test_init(self):
         """Tests the init function with valid parameters."""
-        pass
+        BoundingBox("Test", 0, 0, 1, 1)

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -102,4 +102,5 @@ class TestBoundingBox:
     # Box
     def test_box(self):
         """Tests the 'box' property."""
-        pass
+        bbox = BoundingBox("Test", 0, 0, 1, 1)
+        assert [0, 0, 1, 1] == bbox.center

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -119,8 +119,21 @@ class TestBoundingBox:
 class TestKeypoint:
     """Tests the Keypoint class."""
 
+    # Init
     def test_init(self):
         """Tests the init function with valid parameters."""
-        kp = Point(0.5, 0.5)
+        kp = Point(0.25, 0.25)
         bbox = BoundingBox("Test", 0, 0, 1, 1)
         Keypoint(kp, bbox)
+
+    def test_from_yolo(self):
+        """Tests the from_yolo constructor."""
+        true_kp = Keypoint(Point(0.25, 0.25), BoundingBox("Test", 0, 0, 1, 1))
+        yolo_line = "0 0.25 0.25 0.5 0.5 0.125 0.125"
+        image_width = 2
+        image_height = 2
+        id_to_category = {0: "Test"}
+        created_kp = Keypoint.from_yolo(
+            yolo_line, image_width, image_height, id_to_category
+        )
+        assert true_kp == created_kp

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -92,3 +92,8 @@ class TestBoundingBox:
         """Tests the validate_box_values classmethod with degernate rectangle parameters (left == right == top == bottom)."""
         with pytest.warns(UserWarning, match="box's parameters are equal"):
             BoundingBox("Test", 0, 0, 0, 0)
+
+    # Center
+    def test_center(self):
+        """Tests the 'center' property."""
+        pass

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -20,11 +20,26 @@ class TestBoundingBox:
     # from_yolo
     def test_from_yolo(self):
         """Tests the from_yolo function."""
-        pass
+        true_bbox = BoundingBox("Test", 0, 0, 1, 1)
+        yolo_line = "0 0.25 0.25 0.5 0.5"
+        image_width = 2
+        image_height = 2
+        id_to_category = {0: "Test"}
+        created_bbox = BoundingBox.from_yolo(
+            yolo_line, image_width, image_height, id_to_category
+        )
+        assert true_bbox == created_bbox
 
     def test_from_yolo_category_not_in_id_to_category_dict(self):
         """Tests the from_yolo function where the supplied id is not in the id_to_category dictionary."""
-        pass
+        yolo_line = "0 0.25 0.25 0.5 0.5"
+        image_width = 2
+        image_height = 2
+        id_to_category = {1: "Test"}
+        with pytest.raises(
+            ValueError, match="not found in the id_to_category dictionary"
+        ):
+            BoundingBox.from_yolo(yolo_line, image_width, image_height, id_to_category)
 
     # validate_box_values
     def test_validate_box_values_left_greater_than_right(self):

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -1,0 +1,9 @@
+""" """
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
+
+import pytest
+import annotations

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -7,3 +7,11 @@ sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 import pytest
 import annotations
+
+
+class TestBoundingBox:
+    """Tests the BoundingBox class."""
+
+    def test_init(self):
+        """Tests the init function with valid parameters."""
+        pass

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -108,4 +108,9 @@ class TestBoundingBox:
     # to_yolo
     def test_to_yolo(self):
         """Tests the to_yolo method."""
-        pass
+        bbox = BoundingBox("Test", 0, 0, 1, 1)
+        image_width = 2
+        image_height = 2
+        category_to_id = {"Test": 0}
+        yolo_str = bbox.to_yolo(image_width, image_height, category_to_id)
+        assert yolo_str == "0 0.25 0.25 0.5 0.5"

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -119,4 +119,6 @@ class TestBoundingBox:
 class TestKeypoint:
     """Tests the Keypoint class."""
 
-    pass
+    def test_init(self):
+        """Tests the init function with valid parameters."""
+        pass

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -12,10 +12,21 @@ from annotations import BoundingBox, Keypoint, Point
 class TestBoundingBox:
     """Tests the BoundingBox class."""
 
+    # Init
     def test_init(self):
         """Tests the init function with valid parameters."""
         BoundingBox("Test", 0, 0, 1, 1)
 
+    # from_yolo
+    def test_from_yolo(self):
+        """Tests the from_yolo function."""
+        pass
+
+    def test_from_yolo_category_not_in_id_to_category_dict(self):
+        """Tests the from_yolo function where the supplied id is not in the id_to_category dictionary."""
+        pass
+
+    # validate_box_values
     def test_validate_box_values_left_greater_than_right(self):
         """Tests the validate_box_values classmethod with invalid parameters (left > right)."""
         with pytest.raises(ValueError, match="left side greater than its right side"):

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -18,20 +18,25 @@ class TestBoundingBox:
 
     def test_validate_box_values_left_greater_than_right(self):
         """Tests the validate_box_values classmethod with invalid parameters (left > right)."""
-        pass
+        with pytest.raises(ValueError, match="left side greater than its right side"):
+            BoundingBox("Test", 1, 0, 0, 1)
 
     def test_validate_box_values_top_greater_than_bottom(self):
         """Tests the validate_box_values classmethod with invalid parameters (top > bottom)."""
-        pass
+        with pytest.raises(ValueError, match="top side greater than its bottom side"):
+            BoundingBox("Test", 0, 1, 1, 0)
 
     def test_validate_box_values_left_eq_right(self):
         """Tests the validate_box_values classmethod with degenerate rectangle parameters (left == right)."""
-        pass
+        with pytest.warns(UserWarning, match="left side equals its right side"):
+            BoundingBox("Test", 0, 0, 0, 1)
 
     def test_validate_box_values_top_eq_bottom(self):
         """Tests the validate_box_values classmethod with degenerate rectangle parameters (top == bottom)."""
-        pass
+        with pytest.warns(UserWarning, match="top side equals its bottom side"):
+            BoundingBox("Test", 0, 0, 1, 0)
 
     def test_validate_box_values_left_eq_right_top_eq_bottom(self):
         """Tests the validate_box_values classmethod with degernate rectangle parameters (left == right == top == bottom)."""
-        pass
+        with pytest.warns(UserWarning, match="box's parameters are equal"):
+            BoundingBox("Test", 0, 0, 0, 0)

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -15,3 +15,23 @@ class TestBoundingBox:
     def test_init(self):
         """Tests the init function with valid parameters."""
         BoundingBox("Test", 0, 0, 1, 1)
+
+    def test_validate_box_values_left_greater_than_right(self):
+        """Tests the validate_box_values classmethod with invalid parameters (left > right)."""
+        pass
+
+    def test_validate_box_values_top_greater_than_bottom(self):
+        """Tests the validate_box_values classmethod with invalid parameters (top > bottom)."""
+        pass
+
+    def test_validate_box_values_left_eq_right(self):
+        """Tests the validate_box_values classmethod with degenerate rectangle parameters (left == right)."""
+        pass
+
+    def test_validate_box_values_top_eq_bottom(self):
+        """Tests the validate_box_values classmethod with degenerate rectangle parameters (top == bottom)."""
+        pass
+
+    def test_validate_box_values_left_eq_right_top_eq_bottom(self):
+        """Tests the validate_box_values classmethod with degernate rectangle parameters (left == right == top == bottom)."""
+        pass


### PR DESCRIPTION
# Add tests for the annotations module

This pull request adds unit tests for the annotations module, covering functionalities of the BoundingBox and Keypoint classes.

## Tests for BoundingBox class:
- Validates initialization with different parameters.
- Tests conversion from YOLO and COCO formats (including error handling).
- Tests the validate_box_values method for different corner cases.
- Verifies the properties center and box.
- Tests the to_yolo method for converting to YOLO format.

## Tests for Keypoint class:
- Validates initialization with different parameters.
- Tests conversion from YOLO format (including error handling).
- Tests the validate_keypoint method for out-of-bounds scenarios.
- Tests the to_yolo method for converting to YOLO format.

Also fixed a couple small issues the tests found. Mostly warning and error messages.