### PR TITLE
Add unit tests for annotations and tiling modules

### DIFF
--- a/src/annotations.py
+++ b/src/annotations.py
@@ -153,12 +153,13 @@ class BoundingBox:
         """
         left, top, w, h = coco_annotation["bbox"]
         right, bottom = left + w, top + h
-        category = list(
-            filter(lambda c: c["id"] == coco_annotation["category_id"], categories)
-        )[0].get("name")
-        if category == None:
+        try:
+            category = list(
+                filter(lambda c: c["id"] == coco_annotation["category_id"], categories)
+            )[0].get("name")
+        except IndexError:
             raise ValueError(
-                f"Category {int(coco_annotation['category_id'])} not found in the id_to_category dictionary."
+                f"Category {int(coco_annotation['category_id'])} not found in the categories list."
             )
         return BoundingBox(category, left, top, right, bottom)
 
@@ -202,12 +203,12 @@ class BoundingBox:
             )
         elif left == right:
             warnings.warn(
-                f"Degenerate rectangle detected. The box's left side equals it's right side (Left:{left}, Top:{top}, Right:{right}, Bottom:{bottom}).",
+                f"Degenerate rectangle detected. The box's left side equals its right side (Left:{left}, Top:{top}, Right:{right}, Bottom:{bottom}).",
                 UserWarning,
             )
         elif top == bottom:
             warnings.warn(
-                f"Degenerate rectangle detected. The box's left side equals it's right side (Left:{left}, Top:{top}, Right:{right}, Bottom:{bottom}).",
+                f"Degenerate rectangle detected. The box's top side equals its bottom side (Left:{left}, Top:{top}, Right:{right}, Bottom:{bottom}).",
                 UserWarning,
             )
 

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -1,0 +1,169 @@
+"""Tests for the annotations module."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
+
+import pytest
+from annotations import BoundingBox, Keypoint, Point
+
+
+class TestBoundingBox:
+    """Tests the BoundingBox class."""
+
+    # Init
+    def test_init(self):
+        """Tests the init function with valid parameters."""
+        BoundingBox("Test", 0, 0, 1, 1)
+
+    # from_yolo
+    def test_from_yolo(self):
+        """Tests the from_yolo constructor."""
+        true_bbox = BoundingBox("Test", 0, 0, 1, 1)
+        yolo_line = "0 0.25 0.25 0.5 0.5"
+        image_width = 2
+        image_height = 2
+        id_to_category = {0: "Test"}
+        created_bbox = BoundingBox.from_yolo(
+            yolo_line, image_width, image_height, id_to_category
+        )
+        assert true_bbox == created_bbox
+
+    def test_from_yolo_category_not_in_id_to_category_dict(self):
+        """Tests the from_yolo constructor where the supplied id is not in the id_to_category dictionary."""
+        yolo_line = "0 0.25 0.25 0.5 0.5"
+        image_width = 2
+        image_height = 2
+        id_to_category = {1: "Test"}
+        with pytest.raises(
+            ValueError, match="not found in the id_to_category dictionary"
+        ):
+            BoundingBox.from_yolo(yolo_line, image_width, image_height, id_to_category)
+
+    # from_coco
+    def test_from_coco(self):
+        """Tests the from_coco constructor."""
+        true_bbox = BoundingBox("Test", 0, 0, 1, 1)
+        coco_annotation = {
+            "id": 0,
+            "image_id": 0,
+            "category_id": 0,
+            "bbox": [0, 0, 1, 1],
+        }
+        categories = [{"id": 0, "name": "Test"}]
+        created_bbox = BoundingBox.from_coco(coco_annotation, categories)
+        assert true_bbox == created_bbox
+
+    def test_from_coco_category_not_found_in_(self):
+        """Tests the from_coco constructor where the supplied category is not in the list of category dictionaries."""
+        coco_annotation = {
+            "id": 0,
+            "image_id": 0,
+            "category_id": 0,
+            "bbox": [0, 0, 1, 1],
+        }
+        categories = [{"id": 1, "name": "Test"}]
+        with pytest.raises(ValueError, match="not found in the categories list"):
+            BoundingBox.from_coco(coco_annotation, categories)
+
+    # validate_box_values
+    def test_validate_box_values_left_greater_than_right(self):
+        """Tests the validate_box_values classmethod with invalid parameters (left > right)."""
+        with pytest.raises(ValueError, match="left side greater than its right side"):
+            BoundingBox("Test", 1, 0, 0, 1)
+
+    def test_validate_box_values_top_greater_than_bottom(self):
+        """Tests the validate_box_values classmethod with invalid parameters (top > bottom)."""
+        with pytest.raises(ValueError, match="top side greater than its bottom side"):
+            BoundingBox("Test", 0, 1, 1, 0)
+
+    def test_validate_box_values_left_eq_right(self):
+        """Tests the validate_box_values classmethod with degenerate rectangle parameters (left == right)."""
+        with pytest.warns(UserWarning, match="left side equals its right side"):
+            BoundingBox("Test", 0, 0, 0, 1)
+
+    def test_validate_box_values_top_eq_bottom(self):
+        """Tests the validate_box_values classmethod with degenerate rectangle parameters (top == bottom)."""
+        with pytest.warns(UserWarning, match="top side equals its bottom side"):
+            BoundingBox("Test", 0, 0, 1, 0)
+
+    def test_validate_box_values_left_eq_right_top_eq_bottom(self):
+        """Tests the validate_box_values classmethod with degernate rectangle parameters (left == right == top == bottom)."""
+        with pytest.warns(UserWarning, match="box's parameters are equal"):
+            BoundingBox("Test", 0, 0, 0, 0)
+
+    # Center
+    def test_center(self):
+        """Tests the 'center' property."""
+        bbox = BoundingBox("Test", 0, 0, 1, 1)
+        assert (0.5, 0.5) == bbox.center
+
+    # Box
+    def test_box(self):
+        """Tests the 'box' property."""
+        bbox = BoundingBox("Test", 0, 0, 1, 1)
+        assert [0, 0, 1, 1] == bbox.box
+
+    # to_yolo
+    def test_to_yolo(self):
+        """Tests the to_yolo method."""
+        bbox = BoundingBox("Test", 0, 0, 1, 1)
+        image_width = 2
+        image_height = 2
+        category_to_id = {"Test": 0}
+        yolo_str = bbox.to_yolo(image_width, image_height, category_to_id)
+        assert yolo_str == "0 0.25 0.25 0.5 0.5"
+
+
+class TestKeypoint:
+    """Tests the Keypoint class."""
+
+    # Init
+    def test_init(self):
+        """Tests the init function with valid parameters."""
+        kp = Point(0.25, 0.25)
+        bbox = BoundingBox("Test", 0, 0, 1, 1)
+        Keypoint(kp, bbox)
+
+    # from_yolo
+    def test_from_yolo(self):
+        """Tests the from_yolo constructor."""
+        true_kp = Keypoint(Point(0.25, 0.25), BoundingBox("Test", 0, 0, 1, 1))
+        yolo_line = "0 0.25 0.25 0.5 0.5 0.125 0.125"
+        image_width = 2
+        image_height = 2
+        id_to_category = {0: "Test"}
+        created_kp = Keypoint.from_yolo(
+            yolo_line, image_width, image_height, id_to_category
+        )
+        assert true_kp == created_kp
+
+    # validate_keyoint
+    def test_validate_keypoint_out_of_bounds_x(self):
+        """Tests the validate_keypoint method where the keypoint is not within the left-right bounds."""
+        # Left of box.
+        with pytest.raises(ValueError, match="not in the bounding box"):
+            Keypoint(Point(1, 1), BoundingBox("Test", 2, 0, 3, 2))
+        # Right of box.
+        with pytest.raises(ValueError, match="not in the bounding box"):
+            Keypoint(Point(4, 1), BoundingBox("Test", 2, 0, 3, 2))
+
+    def test_validate_keypoint_out_of_bounds_y(self):
+        """Tests the validate_keypoint method where the keypoint is not within the left-right bounds."""
+        # Above box
+        with pytest.raises(ValueError):
+            Keypoint(Point(1, 1), BoundingBox("Test", 0, 2, 2, 3))
+        # Below box
+        with pytest.raises(ValueError):
+            Keypoint(Point(1, 4), BoundingBox("Test", 0, 2, 2, 3))
+
+    # to_yolo
+    def test_to_yolo(self):
+        """Tests the to_yolo method."""
+        kp = Keypoint(Point(0.25, 0.25), BoundingBox("Test", 0, 0, 1, 1))
+        image_width = 2
+        image_height = 2
+        category_to_id = {"Test": 0}
+        yolo_str = kp.to_yolo(image_width, image_height, category_to_id)
+        assert yolo_str == "0 0.25 0.25 0.5 0.5 0.125 0.125"

--- a/tests/unit_tests/test_tiling.py
+++ b/tests/unit_tests/test_tiling.py
@@ -1,0 +1,233 @@
+"""Tests the tiling module."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
+
+import pytest
+from PIL import Image, ImageChops
+import tiling
+from annotations import BoundingBox
+
+
+@pytest.fixture()
+def test_image():
+    """Creates a PIL Image for testing purposes."""
+    image = Image.new("L", (3, 3))
+    image_data = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+    image.putdata(image_data)
+    return image
+
+
+@pytest.fixture()
+def test_annotations():
+    """Creates a short list of annotations for testing."""
+    return [
+        BoundingBox("Test", 0, 0, 1, 1),
+        BoundingBox("Test", 2, 2, 3, 3),
+        BoundingBox("Test", 3, 3, 4, 4),
+    ]
+
+
+def test_tile_image(test_image):
+    """Function that tests tile_image"""
+
+    def image_from_list(l, size):
+        image = Image.new("L", (size, size))
+        image.putdata(l)
+        return image
+
+    slice_width, slice_height = 2, 2
+    horizontal_overlap_ratio, vertical_overlap_ratio = 0.5, 0.5
+    created_tiles = tiling.tile_image(
+        test_image,
+        slice_width,
+        slice_height,
+        horizontal_overlap_ratio,
+        vertical_overlap_ratio,
+    )
+    true_tiles = [
+        [
+            image_from_list([0, 1, 3, 4], 2),
+            image_from_list([1, 2, 4, 5], 2),
+            image_from_list([2, 0, 5, 0], 2),
+        ],
+        [
+            image_from_list([3, 4, 6, 7], 2),
+            image_from_list([4, 5, 7, 8], 2),
+            image_from_list([5, 0, 8, 0], 2),
+        ],
+        [
+            image_from_list([6, 7, 0, 0], 2),
+            image_from_list([7, 8, 0, 0], 2),
+            image_from_list([8, 0, 0, 0], 2),
+        ],
+    ]
+    assert len(true_tiles) == len(created_tiles)
+    assert len(true_tiles[0]) == len(created_tiles[0])
+    for ix, im_list in enumerate(created_tiles):
+        for jx, im in enumerate(im_list):
+            diff = ImageChops.difference(im, true_tiles[ix][jx])
+            assert diff.getbbox() is None
+
+
+class TestValidateTileParameters:
+    """Class that organizes test functions for validate_tile_parameters."""
+
+    def test_slice_width_too_small(self, test_image):
+        """Tests the validate_tile_parameters function when the slice width is less than or equal to 0."""
+        slice_width, slice_height = 0, 1
+        horizontal_overlap_ratio, vertical_overlap_ratio = 0.5, 0.5
+        with pytest.raises(ValueError, match="slice_width must be"):
+            tiling.validate_tile_parameters(
+                test_image,
+                slice_width,
+                slice_height,
+                horizontal_overlap_ratio,
+                vertical_overlap_ratio,
+            )
+
+    def test_slice_width_too_large(self, test_image):
+        """Tests the validate_tile_parameters function when the slice width is greater than the image width."""
+        slice_width, slice_height = 4, 1
+        horizontal_overlap_ratio, vertical_overlap_ratio = 0.5, 0.5
+        with pytest.raises(ValueError, match="slice_width must be"):
+            tiling.validate_tile_parameters(
+                test_image,
+                slice_width,
+                slice_height,
+                horizontal_overlap_ratio,
+                vertical_overlap_ratio,
+            )
+
+    def test_slice_height_too_small(self, test_image):
+        """Tests the validate_tile_parameters function when the slice height is less than or equal to 0."""
+        slice_width, slice_height = 1, 0
+        horizontal_overlap_ratio, vertical_overlap_ratio = 0.5, 0.5
+        with pytest.raises(ValueError, match="slice_height must be"):
+            tiling.validate_tile_parameters(
+                test_image,
+                slice_width,
+                slice_height,
+                horizontal_overlap_ratio,
+                vertical_overlap_ratio,
+            )
+
+    def test_slice_height_too_large(self, test_image):
+        """Tests the validate_tile_parameters function when the slice height is greater than the image height."""
+        slice_width, slice_height = 1, 4
+        horizontal_overlap_ratio, vertical_overlap_ratio = 0.5, 0.5
+        with pytest.raises(ValueError, match="slice_height must be"):
+            tiling.validate_tile_parameters(
+                test_image,
+                slice_width,
+                slice_height,
+                horizontal_overlap_ratio,
+                vertical_overlap_ratio,
+            )
+
+    def test_horizontal_overlap_ratio_too_small(self, test_image):
+        """Tests the validate_tile_parameters function when the horizontal overlap ratio is less than or equal to 0."""
+        slice_width, slice_height = 1, 1
+        horizontal_overlap_ratio, vertical_overlap_ratio = 0.0, 0.5
+        with pytest.raises(ValueError, match="horizontal_overlap_ratio must be"):
+            tiling.validate_tile_parameters(
+                test_image,
+                slice_width,
+                slice_height,
+                horizontal_overlap_ratio,
+                vertical_overlap_ratio,
+            )
+
+    def test_horizontal_overlap_ratio_too_large(self, test_image):
+        """Tests the validate_tile_parameters function when the horizontal overlap ratio is greater than 1."""
+        slice_width, slice_height = 1, 1
+        horizontal_overlap_ratio, vertical_overlap_ratio = 1.1, 0.5
+        with pytest.raises(ValueError, match="horizontal_overlap_ratio must be"):
+            tiling.validate_tile_parameters(
+                test_image,
+                slice_width,
+                slice_height,
+                horizontal_overlap_ratio,
+                vertical_overlap_ratio,
+            )
+
+    def test_vertical_overlap_ratio_too_small(self, test_image):
+        """Tests the validate_tile_parameters function when the vertical overlap ratio is less than or equal to 0."""
+        slice_width, slice_height = 1, 1
+        horizontal_overlap_ratio, vertical_overlap_ratio = 0.5, 0.0
+        with pytest.raises(ValueError, match="vertical_overlap_ratio must be"):
+            tiling.validate_tile_parameters(
+                test_image,
+                slice_width,
+                slice_height,
+                horizontal_overlap_ratio,
+                vertical_overlap_ratio,
+            )
+
+    def test_vertical_overlap_ratio_too_large(self, test_image):
+        """Tests the validate_tile_parameters function when the vertical overlap ratio is greater than 1."""
+        slice_width, slice_height = 1, 1
+        horizontal_overlap_ratio, vertical_overlap_ratio = 0.5, 1.1
+        with pytest.raises(ValueError, match="vertical_overlap_ratio must be"):
+            tiling.validate_tile_parameters(
+                test_image,
+                slice_width,
+                slice_height,
+                horizontal_overlap_ratio,
+                vertical_overlap_ratio,
+            )
+
+
+def test_generate_tile_coordinates():
+    """Function that tests generate_tile_coordinates."""
+    image_width, image_height = 8, 8
+    slice_width, slice_height = 4, 4
+    horizontal_overlap_ratio, vertical_overlap_ratio = 0.5, 0.5
+
+    created_tile_coordinates = tiling.generate_tile_coordinates(
+        image_width,
+        image_height,
+        slice_width,
+        slice_height,
+        horizontal_overlap_ratio,
+        vertical_overlap_ratio,
+    )
+    true_tile_coordinates = [
+        [(0, 0, 4, 4), (2, 0, 6, 4), (4, 0, 8, 4), (6, 0, 10, 4)],
+        [(0, 2, 4, 6), (2, 2, 6, 6), (4, 2, 8, 6), (6, 2, 10, 6)],
+        [(0, 4, 4, 8), (2, 4, 6, 8), (4, 4, 8, 8), (6, 4, 10, 8)],
+        [(0, 6, 4, 10), (2, 6, 6, 10), (4, 6, 8, 10), (6, 6, 10, 10)],
+    ]
+    assert created_tile_coordinates == true_tile_coordinates
+
+
+def test_tile_annotations(test_annotations):
+    """Function that tests tile_annotations."""
+    image_width, image_height = 4, 4
+    slice_width, slice_height = 3, 3
+    horizontal_overlap_ratio, vertical_overlap_ratio = 0.5, 0.5
+    created_tiled_annotations = tiling.tile_annotations(
+        test_annotations,
+        image_width,
+        image_height,
+        slice_width,
+        slice_height,
+        horizontal_overlap_ratio,
+        vertical_overlap_ratio,
+    )
+    true_tiled_annotations = [
+        [[test_annotations[0], test_annotations[1]], [test_annotations[1]]],
+        [[test_annotations[1]], [test_annotations[1], test_annotations[2]]],
+    ]
+    assert created_tiled_annotations == true_tiled_annotations
+
+
+def test_get_annotations_in_tile(test_annotations):
+    """Function that tests get_annotations_in_tile."""
+    created_annotations_in_tile = tiling.get_annotations_in_tile(
+        test_annotations, [0, 0, 3, 3]
+    )
+    true_annotations_in_tile = [test_annotations[0], test_annotations[1]]
+    assert created_annotations_in_tile == true_annotations_in_tile


### PR DESCRIPTION
This pull request adds unit tests for two modules: annotations and tiling. These tests improve the code coverage and reliability of the codebase.

# Files tested:

## annotations.py
Adds unit tests for the BoundingBox and Keypoint classes (not included in this pull request, assumed to be in a separate file).
## tiling.py
Adds unit tests covering various functionalities:
- tile_image: Validates image tiling for a simple scenario and ensures pixel-wise equality between expected and generated tiles.
- validate_tile_parameters: Tests error handling for invalid tile or overlap ratio parameters.
- generate_tile_coordinates: Verifies generation of tile coordinates for a specific configuration.
- tile_annotations: Validates tiling of annotations based on bounding boxes.
- get_annotations_in_tile: Ensures correct filtering of annotations within a tile area.