### PR TITLE
Add Unit Tests for detection_reassembly Module

### DIFF
--- a/src/detection_reassembly.py
+++ b/src/detection_reassembly.py
@@ -31,17 +31,18 @@ def intersection_over_union(detection_1: Detection, detection_2: Detection) -> f
     """
     area = lambda box: (box[2] - box[0]) * (box[3] - box[1])
 
-    intersection_left = max(detection_1.box[0], detection_2.box[0])
-    intersection_top = max(detection_1.box[1], detection_2.box[1])
-    intersection_right = min(detection_1.box[2], detection_2.box[2])
-    intersection_bottom = min(detection_1.box[3], detection_2.box[3])
+    box_1, box_2 = detection_1.annotation.box, detection_2.annotation.box
+    intersection_left = max(box_1[0], box_2[0])
+    intersection_top = max(box_1[1], box_2[1])
+    intersection_right = min(box_1[2], box_2[2])
+    intersection_bottom = min(box_1[3], box_2[3])
     if intersection_right < intersection_left or intersection_bottom < intersection_top:
         return 0
     intersection_area = area(
-        intersection_left, intersection_top, intersection_right, intersection_bottom
+        [intersection_left, intersection_top, intersection_right, intersection_bottom]
     )
 
-    union_area = area(detection_1.box) + area(detection_2.box) - intersection_area
+    union_area = area(box_1) + area(box_2) - intersection_area
 
     return intersection_area / union_area
 

--- a/tests/unit_tests/test_detection_reassembly.py
+++ b/tests/unit_tests/test_detection_reassembly.py
@@ -6,10 +6,16 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 import pytest
+from typing import List
+from annotations import BoundingBox
+from detections import Detection
 import detection_reassembly
 
 
 @pytest.fixture()
-def test_detections():
+def test_detections() -> List[Detection]:
     """Creates a short list of fake detections for testing purposes."""
-    pass
+    return [
+        Detection(BoundingBox("Test", 0, 0, 1, 1), 1.0),
+        Detection(BoundingBox("Test", 0.5, 0, 1, 1), 0.5),
+    ]

--- a/tests/unit_tests/test_detection_reassembly.py
+++ b/tests/unit_tests/test_detection_reassembly.py
@@ -7,3 +7,9 @@ sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 import pytest
 import detection_reassembly
+
+
+@pytest.fixture()
+def test_detections():
+    """Creates a short list of fake detections for testing purposes."""
+    pass

--- a/tests/unit_tests/test_detection_reassembly.py
+++ b/tests/unit_tests/test_detection_reassembly.py
@@ -18,4 +18,21 @@ def test_detections() -> List[Detection]:
     return [
         Detection(BoundingBox("Test", 0, 0, 1, 1), 1.0),
         Detection(BoundingBox("Test", 0.5, 0, 1, 1), 0.5),
+        Detection(BoundingBox("Test", 2, 2, 3, 3), 0.75),
     ]
+
+
+class TestIntersectionOverUnion:
+    """Tests the intersection_over_union function."""
+
+    def test_intersection_over_union(self, test_detections):
+        """Tests the intersection_over_union function with typical inputs."""
+        pass
+
+    def test_intersection_over_union_no_overlap(self, test_detections):
+        """Tests the intersection_over_union function with non-overlapping detections."""
+        pass
+
+    def test_intersection_over_union_total_overlap(self, test_detections):
+        """Tests the intersection_over_union function with totally overlapping detections."""
+        pass

--- a/tests/unit_tests/test_detection_reassembly.py
+++ b/tests/unit_tests/test_detection_reassembly.py
@@ -25,14 +25,26 @@ def test_detections() -> List[Detection]:
 class TestIntersectionOverUnion:
     """Tests the intersection_over_union function."""
 
-    def test_intersection_over_union(self, test_detections):
+    def test_typical_inputs(self, test_detections):
         """Tests the intersection_over_union function with typical inputs."""
-        pass
+        created_iou = detection_reassembly.intersection_over_union(
+            test_detections[0], test_detections[1]
+        )
+        true_iou = 0.5
+        assert created_iou == true_iou
 
-    def test_intersection_over_union_no_overlap(self, test_detections):
+    def test_inputs_with_no_overlap(self, test_detections):
         """Tests the intersection_over_union function with non-overlapping detections."""
-        pass
+        created_iou = detection_reassembly.intersection_over_union(
+            test_detections[0], test_detections[2]
+        )
+        true_iou = 0
+        assert created_iou == true_iou
 
-    def test_intersection_over_union_total_overlap(self, test_detections):
+    def test_inputs_with_total_overlap(self, test_detections):
         """Tests the intersection_over_union function with totally overlapping detections."""
-        pass
+        created_iou = detection_reassembly.intersection_over_union(
+            test_detections[0], test_detections[0]
+        )
+        true_iou = 1
+        assert created_iou == true_iou

--- a/tests/unit_tests/test_detection_reassembly.py
+++ b/tests/unit_tests/test_detection_reassembly.py
@@ -51,14 +51,22 @@ class TestIntersectionOverUnion:
         assert created_iou == true_iou
 
 
-def test_non_maximum_suppression(test_detections):
-    """Function that tests non_maximum_suppression."""
-    created_filtered_detections = detection_reassembly.non_maximum_suppression(
-        test_detections
-    )
-    true_filtered_detections = [
-        test_detections[0],
-        test_detections[3],
-        test_detections[2],
-    ]
-    assert created_filtered_detections == true_filtered_detections
+class TestNonMaximumSuppression:
+    """Tests the non_maximum_suppression function."""
+
+    def test_typical_inputs(self, test_detections):
+        """Tests the non_maximum_suppression with typical inputs."""
+        created_filtered_detections = detection_reassembly.non_maximum_suppression(
+            test_detections
+        )
+        true_filtered_detections = [
+            test_detections[0],
+            test_detections[3],
+            test_detections[2],
+        ]
+        assert created_filtered_detections == true_filtered_detections
+
+    def test_no_inputs(self):
+        """Tests the non_maximum_suppression function with no detections."""
+        created_filtered_detections = detection_reassembly.non_maximum_suppression([])
+        assert created_filtered_detections == []

--- a/tests/unit_tests/test_detection_reassembly.py
+++ b/tests/unit_tests/test_detection_reassembly.py
@@ -19,6 +19,7 @@ def test_detections() -> List[Detection]:
         Detection(BoundingBox("Test", 0, 0, 1, 1), 1.0),
         Detection(BoundingBox("Test", 0.5, 0, 1, 1), 0.5),
         Detection(BoundingBox("Test", 2, 2, 3, 3), 0.75),
+        Detection(BoundingBox("Test", 2.25, 2.25, 2.75, 2.75), 0.9),
     ]
 
 
@@ -48,3 +49,16 @@ class TestIntersectionOverUnion:
         )
         true_iou = 1
         assert created_iou == true_iou
+
+
+def test_non_maximum_suppression(test_detections):
+    """Function that tests non_maximum_suppression."""
+    created_filtered_detections = detection_reassembly.non_maximum_suppression(
+        test_detections
+    )
+    true_filtered_detections = [
+        test_detections[0],
+        test_detections[3],
+        test_detections[2],
+    ]
+    assert created_filtered_detections == true_filtered_detections

--- a/tests/unit_tests/test_detection_reassembly.py
+++ b/tests/unit_tests/test_detection_reassembly.py
@@ -1,0 +1,9 @@
+"""Tests for the detection_reassembly module."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
+
+import pytest
+import detection_reassembly

--- a/tests/unit_tests/test_tiling.py
+++ b/tests/unit_tests/test_tiling.py
@@ -6,13 +6,14 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 import pytest
+from typing import List
 from PIL import Image, ImageChops
 import tiling
 from annotations import BoundingBox
 
 
 @pytest.fixture()
-def test_image():
+def test_image() -> Image.Image:
     """Creates a PIL Image for testing purposes."""
     image = Image.new("L", (3, 3))
     image_data = [0, 1, 2, 3, 4, 5, 6, 7, 8]
@@ -21,7 +22,7 @@ def test_image():
 
 
 @pytest.fixture()
-def test_annotations():
+def test_annotations() -> List[BoundingBox]:
     """Creates a short list of annotations for testing."""
     return [
         BoundingBox("Test", 0, 0, 1, 1),


### PR DESCRIPTION
This pull request adds unit tests for the detection_reassembly module. The tests cover the following functionalities:

- intersection_over_union function:
    - Typical inputs with expected IoU calculation.
    - Inputs with no overlap between detections.
    - Inputs with totally overlapping detections.
- non_maximum_suppression function:
    - Typical case with overlapping detections and expected filtering based on confidence score.
    - Empty list of detections as input.

These tests ensure the correctness of the core functionalities in detection_reassembly.
