### PR TITLE
Homography

### DIFF
--- a/src/image_registration/homography.py
+++ b/src/image_registration/homography.py
@@ -1,4 +1,28 @@
-""" """
+"""Performs homography transformation on images.
+
+This module provides a function for performing homography transformation on
+images. Homography is a technique used to map points from one image (source)
+to another image (destination) based on corresponding point locations.
+The homography is a linear mapping, so non-linear distortions in the image
+cannot be resolved by the homography alone.
+
+The `homography_transform` function takes a source PIL image, corresponding
+source and destination point lists, and an optional original image size as
+input. It then:
+
+    1. Converts source and destination points to NumPy arrays.
+    2. Validates that both point lists have the same number of elements
+       (and at least 4 points for homography calculation).
+    3. Converts the source PIL image to OpenCV format.
+    4. Calculates the homography matrix using `cv2.findHomography`.
+    5. Warps the source image to the destination perspective using
+       `cv2.warpPerspective`.
+    6. Converts the resulting OpenCV image back to PIL format.
+
+Functions:
+    `homography_transform(src_image, src_points, dest_points, original_image_size=None)`:
+        Performs homography transformation on an image based on corresponding points.
+"""
 
 from typing import List, Tuple
 import cv2

--- a/src/image_registration/homography.py
+++ b/src/image_registration/homography.py
@@ -2,14 +2,55 @@
 
 from typing import List, Tuple
 import cv2
+import numpy as np
 from PIL import Image
 from utilities.image_conversion import pil_to_cv2, cv2_to_pil
 
 
 def homography_transform(
-    image: Image.Image,
+    src_image: Image.Image,
     src_points: List[Tuple[float, float]],
     dest_points: List[Tuple[float, float]],
-):
-    """ """
-    pass
+    original_image_size: Tuple[float, float] = (3300, 2250),
+) -> Image.Image:
+    """Performs homography transformation on an image.
+
+    This function transforms an image (src_image) based on corresponding points
+    between the source and destination images. It calculates the homography matrix
+    and uses it to warp the source image to the perspective of the destination points.
+
+    Args:
+        src_image (Image.Image):
+            A PIL image object representing the source image.
+        src_points (List[Tuple[int, int]]):
+            A list of tuples (x, y) representing points in the source image that correspond
+            to points in the destination image.
+        dest_points (List[Tuple[int, int]]):
+            A list of tuples (x, y) representing points in the destination image that points
+            in the source image correspond to (where the source image should be warped to).
+        original_image_size (Tuple[float, float]):
+            A tuple (width, height) representing the size of the control image.
+    .       Defaults to (3300, 2250).
+
+    Returns:
+        A PIL image object representing the transformed source image.
+
+    Raises:
+        ValueError:
+            If the length of src_points and dest_points don't match (must have the same
+            number of corresponding points), or if there are less than 4 points.
+    """
+    src_points: np.ndarray = np.array(src_points)
+    dest_points: np.ndarray = np.array(dest_points)
+
+    if len(src_points) != len(dest_points):
+        raise ValueError(
+            "Source and destination points must have the same number of elements."
+        )
+    if len(src_points) < 4 or len(dest_points) < 4:
+        raise ValueError("Must have 4 or more points to compute the homography.")
+
+    src_image = pil_to_cv2(src_image)
+    h, _ = cv2.findHomography(src_points, dest_points)
+    dest_image = cv2.warpPerspective(src_image, h, original_image_size)
+    return cv2_to_pil(dest_image)

--- a/src/image_registration/homography.py
+++ b/src/image_registration/homography.py
@@ -1,0 +1,15 @@
+""" """
+
+from typing import List, Tuple
+import cv2
+from PIL import Image
+from utilities.image_conversion import pil_to_cv2, cv2_to_pil
+
+
+def homography_transform(
+    image: Image.Image,
+    src_points: List[Tuple[float, float]],
+    dest_points: List[Tuple[float, float]],
+):
+    """ """
+    pass

--- a/src/utilities/image_conversion.py
+++ b/src/utilities/image_conversion.py
@@ -1,0 +1,57 @@
+"""Converts between PIL and OpenCV image formats.
+
+This module provides functions to convert between Python Imaging Library (PIL)
+image format and OpenCV image format.
+
+**Functions:**
+* `pil_to_cv2(pil_image)`: 
+    Converts a PIL image to a NumPy array representing the image in OpenCV 
+    format (BGR channel order). Raises ValueError if the PIL image mode is 
+    not RGB or BGR.
+* `cv2_to_pil(cv2_image)`:
+    Converts a NumPy array representing an OpenCV image (BGR channel order) 
+    to a PIL image object.
+"""
+
+import cv2
+from PIL import Image
+import numpy as np
+
+
+def pil_to_cv2(pil_image: Image.Image) -> np.ndarray:
+    """Converts a PIL image to OpenCV image format.
+
+    Args:
+        pil_image (Image.Image):
+            A PIL image object.
+
+    Returns:
+        A NumPy array representing the image in OpenCV format (BGR channel order).
+
+    Raises:
+        ValueError:
+            If the input image mode is not compatible with RGB or BGR.
+    """
+    cv2_image = np.array(pil_image)
+    if pil_image.mode not in ("RGB", "BGR"):
+        raise ValueError(
+            f"Unsupported image mode: {pil_image.mode}. Only RGB and BGR modes are supported."
+        )
+    if pil_image.mode == "RGB":
+        cv2_image = cv2_image[:, :, ::-1].copy()
+    return cv2_image
+
+
+def cv2_to_pil(cv2_image: np.ndarray) -> Image.Image:
+    """Converts an OpenCV image to PIL image format.
+
+    Args:
+        cv2_image (np.ndarray):
+            A NumPy array representing an image in OpenCV format (BGR channel order).
+
+    Returns:
+        A PIL image object.
+    """
+    img = cv2.cvtColor(cv2_image, cv2.COLOR_BGR2RGB)
+    pil_image = Image.fromarray(img)
+    return pil_image

--- a/tests/unit_tests/test_annotations.py
+++ b/tests/unit_tests/test_annotations.py
@@ -3,10 +3,10 @@
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src", "utilities")))
+sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 import pytest
-from annotations import BoundingBox, Keypoint, Point
+from utilities.annotations import BoundingBox, Keypoint, Point
 
 
 class TestBoundingBox:

--- a/tests/unit_tests/test_detection_reassembly.py
+++ b/tests/unit_tests/test_detection_reassembly.py
@@ -3,13 +3,13 @@
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src", "utilities")))
+sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 import pytest
 from typing import List
-from annotations import BoundingBox
-from detections import Detection
-import detection_reassembly
+from utilities.annotations import BoundingBox
+from utilities.detections import Detection
+from utilities import detection_reassembly
 
 
 @pytest.fixture()

--- a/tests/unit_tests/test_homography.py
+++ b/tests/unit_tests/test_homography.py
@@ -5,16 +5,31 @@ import os
 
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
-from image_registration import homography
+import pytest
+from PIL import Image
+from image_registration.homography import homography_transform
+
+
+@pytest.fixture()
+def test_pil_image() -> Image.Image:
+    """Creates a PIL Image for testing purposes."""
+    image = Image.new("RGB", (3, 3))
+    return image
 
 
 class TestHomographyTransform:
     """Tests the homography_transform function."""
 
-    def test_not_enough_points():
+    def test_not_enough_points(self, test_pil_image):
         """Tests the homography_tranform function when there are not enough points."""
-        pass
+        with pytest.raises(ValueError, match="Must have 4"):
+            homography_transform(
+                test_pil_image, [(0, 1), (2, 3), (4, 5)], [(1, 2), (3, 4), (5, 6)]
+            )
 
-    def test_unequal_number_of_points():
+    def test_unequal_number_of_points(self):
         """Tests the homography_transform function when there are an unequal number of src and dst points."""
-        pass
+        with pytest.raises(ValueError, match="Source and destination points"):
+            homography_transform(
+                test_pil_image, [(0, 1), (2, 3)], [(1, 2), (3, 4), (5, 6)]
+            )

--- a/tests/unit_tests/test_homography.py
+++ b/tests/unit_tests/test_homography.py
@@ -6,3 +6,15 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 from image_registration import homography
+
+
+class TestHomographyTransform:
+    """Tests the homography_transform function."""
+
+    def test_not_enough_points():
+        """Tests the homography_tranform function when there are not enough points."""
+        pass
+
+    def test_unequal_number_of_points():
+        """Tests the homography_transform function when there are an unequal number of src and dst points."""
+        pass

--- a/tests/unit_tests/test_homography.py
+++ b/tests/unit_tests/test_homography.py
@@ -1,0 +1,8 @@
+"""Tests the homography module."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
+
+from image_registration import homography

--- a/tests/unit_tests/test_image_conversion.py
+++ b/tests/unit_tests/test_image_conversion.py
@@ -1,0 +1,54 @@
+"""Tests for the image_conversion module."""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
+
+import pytest
+from PIL import Image, ImageChops
+import cv2
+import numpy as np
+from utilities import image_conversion
+
+
+@pytest.fixture()
+def test_pil_image() -> Image.Image:
+    """Creates a PIL Image for testing purposes."""
+    image = Image.new("RGB", (3, 3))
+    return image
+
+
+@pytest.fixture()
+def test_cv2_image() -> np.ndarray:
+    """Creates a cv2 image for testing purposes."""
+    return np.zeros((3, 3, 3), np.uint8)
+
+
+class TestPilToCv2:
+    """Tests the pil_to_cv2 function."""
+
+    def test_typical_inputs(self, test_pil_image):
+        """Tests the pil_to_cv2 function with typical inputs."""
+        true_cv2_image = np.array([[(0, 0, 0) for i in range(3)] for j in range(3)])
+        created_cv2_image = image_conversion.pil_to_cv2(test_pil_image)
+        assert np.array_equal(true_cv2_image, created_cv2_image)
+
+    def test_bad_mode(self):
+        """Tests the pil_to_cv2 functions ability to throw an error when the image's mode is not allowed."""
+        image = Image.new("L", (3, 3))
+        image_data = [0, 1, 2, 3, 4, 5, 6, 7, 8]
+        image.putdata(image_data)
+        with pytest.raises(ValueError):
+            image_conversion.pil_to_cv2(image)
+
+
+class TestCv2ToPil:
+    """Tests the cv2_to_pil function."""
+
+    def test_typical_inputs(self, test_cv2_image):
+        """Tests the cv2_to_pil function with typical inputs."""
+        true_pil_image = Image.new("RGB", (3, 3))
+        created_pil_image = image_conversion.cv2_to_pil(test_cv2_image)
+        diff = ImageChops.difference(true_pil_image, created_pil_image)
+        assert diff.getbbox() is None

--- a/tests/unit_tests/test_tiling.py
+++ b/tests/unit_tests/test_tiling.py
@@ -3,13 +3,13 @@
 import sys
 import os
 
-sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src", "utilities")))
+sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 import pytest
 from typing import List
 from PIL import Image, ImageChops
-import tiling
-from annotations import BoundingBox
+from utilities.annotations import BoundingBox
+from utilities import tiling
 
 
 @pytest.fixture()


### PR DESCRIPTION
This pull request introduces three new files for performing homography transformation on images:

### image_registration/homography.py: 
This file contains the core functionality for performing homography transformation. It defines a function homography_transform that takes a source image, corresponding source and destination point lists (representing keypoints in the images), and an optional original image size as input. It calculates the homography matrix and warps the source image to the anchor points on a destination image (in our case, a perfectly aligned copy of the sheet).

### utilities/image_conversion.py: 
This file provides utility functions for converting between PIL and OpenCV image formats. It includes functions pil_to_cv2 and cv2_to_pil for seamless conversion between the two image processing libraries.

### tests/test_homography.py: 
This file contains unit tests for the homography_transform function. It tests for scenarios with insufficient points and unequal numbers of source and destination points, ensuring the function raises errors as expected. It does not yet test the functionality of the homography_transform function. This will be added later.

This addition provides a robust solution for homography transformation in Python, with functionalities for image conversion and unit tests for validation.