### PR TITLE
Fixed bug in tile_annotations.

### DIFF
--- a/src/utilities/annotations.py
+++ b/src/utilities/annotations.py
@@ -202,6 +202,28 @@ class BoundingBox:
         """A list containing this `BoundingBox`'s [left, top, right, bottom]."""
         return [self.left, self.top, self.right, self.bottom]
 
+    def set_box(self, new_left: int, new_top: int, new_right: int, new_bottom: int):
+        """Sets this BoundingBox's values for left, top, right, bottom.
+
+        Args :
+            new_left (int):
+                The new left side for the box.
+            new_top (int):
+                The new top side for the box.
+            new_right (int):
+                The new right side for the box.
+            new_bottom (int):
+                The new bottom side for the box.
+        """
+        self.validate_box_values(new_left, new_top, new_right, new_bottom)
+        return BoundingBox(
+            category=self.category,
+            left=new_left,
+            top=new_top,
+            right=new_right,
+            bottom=new_bottom,
+        )
+
     def to_yolo(
         self, image_width: int, image_height: int, category_to_id: Dict[str, int]
     ) -> str:
@@ -343,6 +365,44 @@ class Keypoint:
     def box(self) -> Tuple[float]:
         """This keypoints boundingbox's [left, top, right, bottom]."""
         return self.bounding_box.box
+
+    def set_box(
+        self, new_left: int, new_top: int, new_right: int, new_bottom: int
+    ) -> BoundingBox:
+        """Sets this Keypoints's BoundingBox's values for left, top, right, bottom.
+
+        Args:
+            new_left (int):
+                The new left side for the box.
+            new_top (int):
+                The new top side for the box.
+            new_right (int):
+                The new right side for the box.
+            new_bottom (int):
+                The new bottom side for the box.
+
+        Returns: A new Keypoint with a new bounding box.
+        """
+        return Keypoint(
+            point=self.point,
+            bounding_box=self.bounding_box.set_box(
+                new_left, new_top, new_right, new_bottom
+            ),
+        )
+
+    def set_keypoint(self, new_x: int, new_y: int) -> "Keypoint":
+        """Sets this Keypoint's Keypoint to a new point.
+
+        Args:
+            new_x (int):
+                The new x value for the Keypoint.
+            new_y (int):
+                The new y value for the Keypoint.
+
+        Returns: A new Keypoint with a new Point as its keypoint.
+        """
+        self.validate_keypoint(self.bounding_box, Point(new_x, new_y))
+        return Keypoint(Point(new_x, new_y), self.bounding_box)
 
     def to_yolo(
         self, image_width: int, image_height: int, category_to_id: Dict[str, int]

--- a/tests/unit_tests/test_tiling.py
+++ b/tests/unit_tests/test_tiling.py
@@ -219,8 +219,35 @@ def test_tile_annotations(test_annotations):
         vertical_overlap_ratio,
     )
     true_tiled_annotations = [
-        [[test_annotations[0], test_annotations[1]], [test_annotations[1]]],
-        [[test_annotations[1]], [test_annotations[1], test_annotations[2]]],
+        [
+            [test_annotations[0], test_annotations[1]],
+            [
+                test_annotations[1].set_box(
+                    new_left=0,
+                    new_top=test_annotations[1].top,
+                    new_right=1,
+                    new_bottom=test_annotations[1].bottom,
+                )
+            ],
+        ],
+        [
+            [
+                test_annotations[1].set_box(
+                    new_left=test_annotations[1].left,
+                    new_top=0,
+                    new_right=test_annotations[1].right,
+                    new_bottom=1,
+                )
+            ],
+            [
+                test_annotations[1].set_box(
+                    new_left=0, new_top=0, new_right=1, new_bottom=1
+                ),
+                test_annotations[2].set_box(
+                    new_left=1, new_top=1, new_right=2, new_bottom=2
+                ),
+            ],
+        ],
     ]
     assert created_tiled_annotations == true_tiled_annotations
 


### PR DESCRIPTION
There exists a bug in tile_annotations where the annotation's coordinates were simply not getting corrected based on which tile they belonged to. This would cause a box to be in pixels that didn't exist in the image.

To solve this, there is a new method for BoundingBox that sets the box's values called set_box. Under the hood this just returns a new object with the new values (and the same category). Keypoint was updated to have the same function, and although it doesn't strictly need to, it also returns a whole new Keypoint. Also added a correct_keypoint method that does much the same thing as set_box does for BoundingBox. 
Note that you can change the bounding box of a keypoint with the same method set_box such that it is an invalid keypoint (keypoint is not in the box), but you cannot change its keypoint via set_keypoint in a way that makes it invalid.