### PR TITLE
Ruff Linting

### DIFF
--- a/src/image_registration/homography.py
+++ b/src/image_registration/homography.py
@@ -7,7 +7,7 @@ The homography is a linear mapping, so non-linear distortions in the image
 cannot be resolved by the homography alone.
 
 The `homography_transform` function takes a source PIL image, corresponding
-source and destination point lists, and an original image size as input. 
+source and destination point lists, and an original image size as input.
 It then:
 
     1. Converts source and destination points to NumPy arrays.

--- a/src/object_detection_models/ultralytics_yolov8.py
+++ b/src/object_detection_models/ultralytics_yolov8.py
@@ -117,6 +117,6 @@ class UltralyticsYOLOv8(ObjectDetectionModel):
                 )
                 for ix, d in enumerate(detections)
             ]
-        except Exception as e:
+        except Exception:
             pass
         return detections

--- a/src/object_detection_models/ultralytics_yolov8.py
+++ b/src/object_detection_models/ultralytics_yolov8.py
@@ -1,8 +1,8 @@
 """This module implements the `UltralyticsYOLOv8` wrapper class
 
-The `UltralyticsYOLOv8` class, which inherits from the `ObjectDetectionModel` interface, 
-provides a wrapper for the YOLOv8 object detection model from the Ultralytics library. 
-It enables you to use the YOLOv8 model within your program through the common interface defined 
+The `UltralyticsYOLOv8` class, which inherits from the `ObjectDetectionModel` interface,
+provides a wrapper for the YOLOv8 object detection model from the Ultralytics library.
+It enables you to use the YOLOv8 model within your program through the common interface defined
 in `object_detection_model.py`.
 
 Key functionalities include:
@@ -11,10 +11,10 @@ Key functionalities include:
     - Performing object detection on an image using the YOLOv8 model.
     - Converting the YOLOv8 model's output to a list of Detection objects.
 
-These `Detection` objects encapsulate details about detected objects, including bounding boxes, 
+These `Detection` objects encapsulate details about detected objects, including bounding boxes,
 confidence scores, and potentially keypoints (if available in the model's output).
 
-This approach simplifies the integration and usage of YOLOv8 within this program, promoting code 
+This approach simplifies the integration and usage of YOLOv8 within this program, promoting code
 modularity and reusability.
 """
 

--- a/src/utilities/annotations.py
+++ b/src/utilities/annotations.py
@@ -1,4 +1,4 @@
-"""This module defines classes for representing bounding boxes and keypoints associated with objects in images. 
+"""This module defines classes for representing bounding boxes and keypoints associated with objects in images.
 
 It also provides helper functions for constructing these objects from YOLO formatted labels.
 """
@@ -10,7 +10,7 @@ import warnings
 
 class Point:
     """The `Point` class is a struct which contains an x and y value for a point.
-    
+
     Attributes :
         `x` (float):
             The x coordinate for the point.
@@ -18,7 +18,7 @@ class Point:
             The y coordinate for the point.
     """
 
-    def __init__(self, x:float, y:float):
+    def __init__(self, x: float, y: float):
         """inits this point."""
         self.x = x
         self.y = y

--- a/src/utilities/tiling.py
+++ b/src/utilities/tiling.py
@@ -1,10 +1,10 @@
 """This module provides functions for splitting an image and its annotations into smaller, overlapping tiles.
 
-The `tile_image` function splits a PIL `Image` object into a grid of tiles with a specified size and overlap ratio. 
+The `tile_image` function splits a PIL `Image` object into a grid of tiles with a specified size and overlap ratio.
 It handles padding the image with black pixels if necessary to ensure all tiles fit perfectly within the image boundaries.
 
-The `tile_annotations` function is a sister function to `tile_image` and can be used to tile annotations associated with the 
-image using (nearly) the same parameters as `tile_image`. It assumes annotations implement a `'box'` property representing 
+The `tile_annotations` function is a sister function to `tile_image` and can be used to tile annotations associated with the
+image using (nearly) the same parameters as `tile_image`. It assumes annotations implement a `'box'` property representing
 their location within the image. Each annotation is assigned to the tile(s) that completely enclose its bounding box.
 """
 

--- a/tests/unit_tests/test_image_conversion.py
+++ b/tests/unit_tests/test_image_conversion.py
@@ -7,7 +7,6 @@ sys.path.insert(0, os.path.abspath(os.path.join("..", "..", "src")))
 
 import pytest
 from PIL import Image, ImageChops
-import cv2
 import numpy as np
 from utilities import image_conversion
 


### PR DESCRIPTION
## Ruff linter formatting and fixing

Ultimately, the Ruff linter was chosen for this issue due to faster compiling and discussion with teammates.

This tool can be installed with `pip install ruff`

Code was reformatted within the src folder (none required for tests folder), 
which can be done in the terminal using `ruff format ./[folder]`

Also, safe fixes (where ruff is positive changes won't alter code behavior) were made on the src and tests folders, 
which can be done in the terminal using `ruff check --fix ./[folder]`

To simply see what recommended changes can be made, the command `ruff check ./[folder]` is used.

The primary changes made by ruff in this issue are for spacing. 