### PR TITLE
Adjustments for test_clustering.py to work given new changes.

### DIFF
--- a/src/label_clustering/clustering_methods.py
+++ b/src/label_clustering/clustering_methods.py
@@ -6,7 +6,6 @@ This module contains functions for clustering labels based on their bounding box
 # Built-in imports
 import re
 from typing import Callable, Dict, List, Literal, Tuple
-from functools import reduce
 
 # External imports
 import numpy as np


### PR DESCRIPTION
Given the new changes you made, I had to adjust some things for the clustering tests to work again:

- There were several errors in the test_clustering.py file. I had to add some commas to a function that we changed, update a function name to match what we changed the name to, and then make the kmeans, dbscan, and agglomerative functions public functions so they can be successfully imported and passed as callables.
- In the test_clustering file added a section that turned the yolo data into a list of BoundingBox'es so the isolation of relevant labels can happen (it expects a list of bounding boxes).
- The __time_correction function no longer was doing time correction, I believe since we are making the Cluster object labels immutable. I made a change that fixed this issue.

I did notice that we are no longer calling the `__remove_bb_outliers` when isolating relevant bounding boxes for the bp/hr graph. I think Matt used this function to filter out erroneous bounding boxes that may come up in the area around the expected axis that are far enough to be excluded. Is there a reason we decided to not use this or should we add that back?