### PR TITLE
Extract Inhaled Volatile Drug Data from Handwritten Numbers

### DIFF
--- a/src/extraction/inhaled_volatile.py
+++ b/src/extraction/inhaled_volatile.py
@@ -1,0 +1,1 @@
+"""Extracts the inhaled volatile drug data."""

--- a/src/extraction/inhaled_volatile.py
+++ b/src/extraction/inhaled_volatile.py
@@ -1,1 +1,12 @@
 """Extracts the inhaled volatile drug data."""
+
+# Built-in imports
+from typing import Dict
+
+# Internal imports
+from blood_pressure_and_heart_rate import find_timestamp, find_value
+
+
+def extract_inhaled_volatile() -> Dict[str, str]:
+    """ """
+    pass

--- a/src/extraction/inhaled_volatile.py
+++ b/src/extraction/inhaled_volatile.py
@@ -1,12 +1,34 @@
 """Extracts the inhaled volatile drug data."""
 
 # Built-in imports
-from typing import Dict
+from typing import Dict, List, Tuple
 
 # Internal imports
-from blood_pressure_and_heart_rate import find_timestamp, find_value
+from utilities.detections import Detection
 
 
-def extract_inhaled_volatile() -> Dict[str, str]:
-    """ """
+def extract_inhaled_volatile(
+    digit_detections: List[Detection],
+    legend_locations: Dict[str, Tuple[float, float]],
+    document_detections: List[Detection],
+    im_width: int,
+    im_height: int,
+) -> Dict[str, str]:
+    """Extracts the inhaled volatile gas data from the number detections.
+
+    Args:
+        `digit_detections` (List[Detection]):
+            The handwritten numbers that have been detected.
+        `legend_locations` (Dict[str, Tuple[float, float]]):
+            The location of the timestamps and mmhg/bpm values on the legend.
+        `document_detections` (List[Detection]):
+            The location of document landmarks that have been detected.
+        `im_width` (int):
+            The width of the image the detections were made on.
+        `im_height` (int):
+            The height of the image the detections were made on.
+
+    Returns:
+        A dictionary mapping timestamps to inhaled volatile gas data.
+    """
     pass

--- a/src/extraction/inhaled_volatile.py
+++ b/src/extraction/inhaled_volatile.py
@@ -1,9 +1,9 @@
 """Extracts the inhaled volatile drug data."""
 
 # Built-in imports
-from operator import attrgetter
 from functools import reduce
 from itertools import pairwise
+from operator import attrgetter
 from typing import Dict, List, Optional, Tuple
 
 # Internal imports

--- a/src/extraction/inhaled_volatile.py
+++ b/src/extraction/inhaled_volatile.py
@@ -1,7 +1,9 @@
 """Extracts the inhaled volatile drug data."""
 
 # Built-in imports
-from typing import Dict, List, Tuple
+from operator import attrgetter
+from functools import reduce
+from typing import Dict, List, Optional, Tuple
 
 # Internal imports
 from utilities.detections import Detection
@@ -31,4 +33,61 @@ def extract_inhaled_volatile(
     Returns:
         A dictionary mapping timestamps to inhaled volatile gas data.
     """
-    pass
+    inhaled_volatile_digits: List[Detection] = get_inhaled_volatile_digits(
+        digit_detections,
+        document_detections,
+    )
+
+
+def get_inhaled_volatile_digits(
+    digit_detections: List[Detection], document_detections: List[Detection]
+) -> List[Detection]:
+    """Filters for the digit detections that are within the inhaled volatile section.
+
+    args:
+        `digit_detections` (List[Detection]):
+            The handwritten numbers that have been detected.
+        `document_detections` (List[Detection]):
+            The location of document landmarks that have been detected.
+
+    Returns:
+        A filtered list of detections holding only those that are in the inhaled volatile section.
+    """
+
+    def get_detection_by_name(name: str) -> Optional[Detection]:
+        try:
+            return list(
+                filter(lambda d: d.annotation.category == name, document_detections)
+            )[0]
+        except:
+            return None
+
+    def average_with_nones(list_with_nones: List[Optional[float]]) -> float:
+        add_with_none = lambda acc, x: acc + x if x is not None else acc
+        len_with_none = lambda l: len(list(filter(lambda x: x is not None, l)))
+        return reduce(add_with_none, list_with_nones) / len_with_none(list_with_nones)
+
+    inhaled_volatile: Optional[Detection] = get_detection_by_name("inhaled_volatile")
+    inhaled_exhaled: Optional[Detection] = get_detection_by_name("inhaled_exhaled")
+    fluid_blood_product: Optional[Detection] = get_detection_by_name(
+        "fluid_blood_product"
+    )
+    total: Optional[Detection] = get_detection_by_name("total")
+
+    if any(
+        [
+            all([inhaled_volatile is None, inhaled_exhaled is None]),
+            all([fluid_blood_product is None, total is None]),
+        ]
+    ):
+        raise ValueError("Cannot find document landmarks to filter digits.")
+
+    get_center = attrgetter("annotation.center")
+    top: float = average_with_nones(
+        [get_center(inhaled_volatile)[1], get_center(inhaled_exhaled)[1]]
+    )
+    bottom: float = average_with_nones(
+        [get_center(fluid_blood_product)[1], get_center(total)[1]]
+    )
+
+    return list(filter(lambda det: top < get_center(det)[1] < bottom, digit_detections))

--- a/src/extraction/physiological_indicators.py
+++ b/src/extraction/physiological_indicators.py
@@ -2,6 +2,7 @@
 
 # Built-in imports
 from itertools import pairwise
+from operator import attrgetter
 from typing import Dict, List, Tuple
 
 # Internal imports
@@ -50,9 +51,9 @@ def extract_physiological_indicators(
             digit_detections,
         )
     )
-    physiological_digit_boxes: List[BoundingBox] = [
-        pd.annotation for pd in physiological_digit_detections
-    ]
+    physiological_digit_boxes: List[BoundingBox] = list(
+        map(attrgetter("annotation"), physiological_digit_detections)
+    )
     fifteen_minute_intervals: Dict[str, Tuple[float, float]] = {
         k: v
         for (k, v) in legend_locations.items()


### PR DESCRIPTION
This pull request introduces the `extract_inhaled_volatile.py` file within the project. This file facilitates the extraction of inhaled volatile gas data from detected handwritten digits.


There are two functions, with only one that needs to be called externally.
* **`extract_inhaled_volatile` Function:** 
  * Takes digit detections, legend locations (timestamps and units), and document landmark detections.
  * Filters digit detections within the "inhaled volatile" section based on landmark positions.
  * Maps timestamps to extracted data points by associating digits with their corresponding time intervals.
  * Returns a dictionary mapping timestamps to inhaled volatile gas data (e.g., "0.5" or "12.7").

* **`get_inhaled_volatile_digits` Function:**
  * Filters the provided digit detections based on their location within the "inhaled volatile" section.
  * Employs document landmark detections (like "inhaled_volatile" and "total") to define the section boundaries.
