### PR TITLE
Add a Custom Sorting Function for NMS

### DIFF
--- a/ChartExtractor/extraction/checkboxes.py
+++ b/ChartExtractor/extraction/checkboxes.py
@@ -133,6 +133,7 @@ def detect_checkboxes(
         detections=detections,
         threshold=0.8,
         overlap_comparator=intersection_over_minimum,
+        sorting_fn=lambda det: det.annotation.area * det.annotation.confidence,
     )
     return [det.annotation for det in detections]
 

--- a/ChartExtractor/extraction/extraction.py
+++ b/ChartExtractor/extraction/extraction.py
@@ -331,7 +331,9 @@ def make_document_landmark_detections(
         MODEL_CONFIG["intraoperative_document_landmarks"]["vert_overlap_proportion"],
     )
     detections = non_maximum_suppression(
-        detections, overlap_comparator=intersection_over_minimum
+        detections,
+        overlap_comparator=intersection_over_minimum,
+        sorting_fn=lambda det: det.annotation.area * det.confidence,
     )
     del document_model
     return detections
@@ -479,13 +481,22 @@ def make_bp_and_hr_detections(
     )
 
     sys_dets: List[Detection] = non_maximum_suppression(
-        sys_dets, 0.5, intersection_over_minimum
+        sys_dets,
+        0.5,
+        intersection_over_minimum,
+        lambda det: det.annotation.area * det.confidence,
     )
     dia_dets: List[Detection] = non_maximum_suppression(
-        dia_dets, 0.5, intersection_over_minimum
+        dia_dets,
+        0.5,
+        intersection_over_minimum,
+        lambda det: det.annotation.area * det.confidence,
     )
     hr_dets: List[Detection] = non_maximum_suppression(
-        hr_dets, 0.5, intersection_over_minimum
+        hr_dets,
+        0.5,
+        intersection_over_minimum,
+        lambda det: det.annotation.area * det.confidence,
     )
 
     dets: List[Detection] = sys_dets + dia_dets + hr_dets

--- a/ChartExtractor/extraction/extraction_utilities.py
+++ b/ChartExtractor/extraction/extraction_utilities.py
@@ -146,6 +146,7 @@ def detect_numbers(
         detections=detections,
         threshold=0.5,
         overlap_comparator=intersection_over_minimum,
+        sorting_fn=lambda det: det.annotation.area * det.confidence,
     )
     return detections
 

--- a/ChartExtractor/utilities/annotations.py
+++ b/ChartExtractor/utilities/annotations.py
@@ -223,6 +223,11 @@ class BoundingBox:
         """A list containing this `BoundingBox`'s [left, top, right, bottom]."""
         return [self.left, self.top, self.right, self.bottom]
 
+    @property
+    def area(self) -> float:
+        """The area of the box."""
+        return (self.right - self.left) * (self.bottom - self.top)
+
     def set_box(self, new_left: int, new_top: int, new_right: int, new_bottom: int):
         """Sets this BoundingBox's values for left, top, right, bottom.
 

--- a/ChartExtractor/utilities/detection_reassembly.py
+++ b/ChartExtractor/utilities/detection_reassembly.py
@@ -95,6 +95,7 @@ def non_maximum_suppression(
     overlap_comparator: Callable[
         [Detection, Detection], float
     ] = intersection_over_union,
+    sorting_fn: Callable[[Detection], bool] = lambda d: d.confidence,
 ) -> List[Detection]:
     """Applies Non-Maximum Suppression (NMS) to a list of detections.
 
@@ -117,7 +118,7 @@ def non_maximum_suppression(
     Returns:
         A list of `Detection` objects containing the filtered detections after applying NMS.
     """
-    detections = sorted(detections, key=lambda d: d.confidence, reverse=True)
+    detections = sorted(detections, key=sorting_fn, reverse=True)
     ix = 0
     while ix < len(detections):
         jx = ix + 1


### PR DESCRIPTION
Traditionally, non-maximum suppression sorts all boxes by confidence, then if another lower confidence detection overlaps with a higher confidence one, the lower confidence detection is deleted.  

Due to the software using tiling, even half-detected objects are assigned full confidence, leading to bad performance using standard NMS. A quick solution to this is to sort boxes by area rather than confidence, and take higher area boxes. This is exactly what this PR does: add a new parameter to the NMS function that is a function that is passed to the built-in Python "sorted" function. Anywhere in the current code where the NMS function is called, a new function is passed in for this new parameter that sorts by the bounding box's area weighted by its confidence.  

This is a quick fix for this issue. A better long term solution will be to add custom training to the YOLO models that penalizes the models less based on how much the object is cut off on the tile.