### PR TITLE
Switch ObjectDetectionModel to protocol from an abstractbaseclass

### DIFF
--- a/ChartExtractor/object_detection_models/object_detection_model.py
+++ b/ChartExtractor/object_detection_models/object_detection_model.py
@@ -1,64 +1,28 @@
-"""This module defines the `ObjectDetectionModel` interface, which serves as a base class
+"""This module defines the `ObjectDetectionModel` protocol, which serves as a structural subtype
 for any object detection model to be used with this program.
 
-The field of object detection is constantly evolving, with new and improved models
-emerging frequently. This interface facilitates the integration and testing of such models
-within the program. Instead of rewriting functionality for each new detector, developers can
-create subclasses that inherit from `ObjectDetectionModel`. As long as these subclasses
-override the `__call__` method to handle object detection on a PIL image and return a list
-of `Detection` objects, existing code remains compatible.
+This protocol will help us define core functionality between objects that adhere to this
+protocol without relying on inheritance.
+
+Implementers of this protocol should explicitly subclass it to enable static checking.
 
 This approach promotes modularity, flexibility, and future-proofing of the program.
 """
 
 # Built-in Imports
-from abc import ABC, abstractmethod
 from pathlib import Path
 from PIL import Image
-from typing import List
+from typing import List, Protocol
 
 # Internal Imports
 from ..utilities.detections import Detection
 
 
-class ObjectDetectionModel(ABC):
+class ObjectDetectionModel(Protocol):
     """Abstract base class for object detection models.
 
     This class defines the interface that all concrete object detection models must adhere to.
     """
-
-    @staticmethod
-    @abstractmethod
-    def from_weights_path(model_weights_path: Path) -> "ObjectDetectionModel":
-        """Initializes the ObjectDetectionModel from a path to its weights.
-
-        Args:
-            model_path (Path):
-                The path to the model's weights file.
-
-        Raises:
-            FileNotFoundError:
-                If the filepath does not lead to a file.
-
-        Returns:
-            ObjectDetectionModel:
-                An instance of the concrete subclass initialized from the weights.
-        """
-        pass
-
-    @staticmethod
-    @abstractmethod
-    def from_model(model) -> "ObjectDetectionModel":
-        """Initializes the ObjectDetectionModel from a model object.
-
-        Args:
-            model:
-                An object from another package that performs object detection.
-
-        Returns:
-            ObjectDetectionModel: An instance of the concrete subclass initialized from the model.
-        """
-        pass
 
     @abstractmethod
     def __call__(self, image: Image.Image) -> List[Detection]:

--- a/ChartExtractor/object_detection_models/object_detection_model.py
+++ b/ChartExtractor/object_detection_models/object_detection_model.py
@@ -11,7 +11,6 @@ This approach promotes modularity, flexibility, and future-proofing of the progr
 
 # Built-in Imports
 from pathlib import Path
-from PIL import Image
 from typing import List, Protocol
 
 # Internal Imports
@@ -25,12 +24,12 @@ class ObjectDetectionModel(Protocol):
     """
 
     @abstractmethod
-    def __call__(self, image: Image.Image) -> List[Detection]:
+    def __call__(self, image) -> List[Detection]:
         """Detects objects on the image.
 
         Args:
-            image (Image.Image):
-                A PIL image that this model detects on.
+            image:
+                An image that this model detects on.
 
         Returns (List[Detection]):
             A list of Detection objects.

--- a/ChartExtractor/object_detection_models/object_detection_model.py
+++ b/ChartExtractor/object_detection_models/object_detection_model.py
@@ -23,7 +23,6 @@ class ObjectDetectionModel(Protocol):
     This class defines the interface that all concrete object detection models must adhere to.
     """
 
-    @abstractmethod
     def __call__(self, image) -> List[Detection]:
         """Detects objects on the image.
 

--- a/ChartExtractor/object_detection_models/onnx_yolov11_detection.py
+++ b/ChartExtractor/object_detection_models/onnx_yolov11_detection.py
@@ -19,7 +19,7 @@ modularity and reusability.
 
 # Built-in imports
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Literal, Tuple
 
 # External imports
 import cv2
@@ -178,7 +178,7 @@ class OnnxYolov11Detection(ObjectDetectionModel):
         Returns:
             A preprocessed image.
         """
-        if method == "letterbox":
+        if resize_method == "letterbox":
             image, _ = self.letterbox(image, (self.input_im_width, self.input_im_height))
         else:
             image: np.array = cv2.resize(

--- a/ChartExtractor/object_detection_models/onnx_yolov11_detection.py
+++ b/ChartExtractor/object_detection_models/onnx_yolov11_detection.py
@@ -71,12 +71,6 @@ class OnnxYolov11Detection(ObjectDetectionModel):
         self.input_im_height = input_im_height
         self.classes = self.load_classes(model_metadata_filepath)
 
-    def from_model(self):
-        pass
-
-    def from_weights_path(self):
-        pass
-
     @staticmethod
     def load_classes(model_metadata_filepath: Path) -> Dict:
         """Loads the classes from a yaml file into a list.

--- a/ChartExtractor/object_detection_models/onnx_yolov11_pose_single.py
+++ b/ChartExtractor/object_detection_models/onnx_yolov11_pose_single.py
@@ -72,12 +72,6 @@ class OnnxYolov11PoseSingle(ObjectDetectionModel):
         self.input_im_height = input_im_height
         self.classes = self.load_classes(model_metadata_filepath)
 
-    def from_model(self):
-        pass
-
-    def from_weights_path(self):
-        pass
-
     @staticmethod
     def load_classes(model_metadata_filepath: Path) -> Dict:
         """Loads the classes from a yaml file into a list.

--- a/ChartExtractor/object_detection_models/onnx_yolov11_pose_single.py
+++ b/ChartExtractor/object_detection_models/onnx_yolov11_pose_single.py
@@ -181,7 +181,7 @@ class OnnxYolov11PoseSingle(ObjectDetectionModel):
         Returns:
             A preprocessed image.
         """
-        if method == "letterbox":
+        if resize_method == "letterbox":
             image, _ = self.letterbox(image, (self.input_im_width, self.input_im_height))
         else:
             image: np.array = cv2.resize(


### PR DESCRIPTION
This PR changes ObjectDetectionModel from an abstractbaseclass that was being used as an interface to a protocol which only needs the __call__ dunder method to be implemented. This change clarifies the role of ObjectDetectionModel.

closes #55 