### PR TITLE
Add single point homography fn

### DIFF
--- a/ChartExtractor/point_registration/homography.py
+++ b/ChartExtractor/point_registration/homography.py
@@ -1,8 +1,9 @@
 """Module for remapping points using a homography transform.
 
-This module exposes a two functions, (1) find_homography, which is a thin wrapper around opencv's
-findHomography function that provides more robust error messages for this libraries usage, and
-(2) transform_point, which takes a point and a homography matrix and transforms the point.
+This module exposes two functions, (1) find_homography, which is a thin wrapper around opencv's
+findHomography function that restricts the original function's usage to only 2d points, and
+provides more robust error messages for this libraries usage, and (2) transform_point, which takes 
+a point and a homography matrix and transforms the point.
 
 Functions:
     find_homography(source_points: List[Tuple[int, int]], destination_points: List[Tuple[int, int]])

--- a/ChartExtractor/point_registration/homography.py
+++ b/ChartExtractor/point_registration/homography.py
@@ -83,4 +83,9 @@ def transform_point(
     Returns:
         A point which has been transformed by the homography.
     """
-    pass
+    if len(point) != 2:
+        raise ValueError(f"Point is not two dimensional: {point}.")
+    
+    remapped_point = homography_matrix.dot(np.array([point[0], point[1], 1]))
+    remapped_point /= remapped_point[2]
+    return (remapped_point[0], remapped_point[1])

--- a/ChartExtractor/point_registration/homography.py
+++ b/ChartExtractor/point_registration/homography.py
@@ -1,7 +1,7 @@
 """Module for remapping points using a homography transform.
 
 This module exposes a two functions, (1) find_homography, which is a thin wrapper around opencv's
-findHomography function so that cv2 doesn't have to be imported where this is used, and
+findHomography function that provides more robust error messages for this libraries usage, and
 (2) transform_point, which takes a point and a homography matrix and transforms the point.
 
 Functions:
@@ -23,6 +23,8 @@ def find_homography(
     destination_points: List[Tuple[int, int]],
 ) -> np.ndarray:
     """A thin wrapper around opencv's findHomography function.
+
+    Provides some additional checks and more informative errors.
     
     Args:
         source_points (List[Tuple[int, int]]):
@@ -35,7 +37,37 @@ def find_homography(
         to transform points according to the transformation that remaps the source points to the
         destination points.
     """
-    pass
+    too_few_source_points: bool = len(source_points) < 4
+    too_few_destination_points: bool = len(destination_points) < 4
+    unequal_point_sets: bool = len(source_points) != len(destination_points)
+    inconsistent_source_point_dimenstions: bool = len(set([len(p) for p in source_points])) == 1
+    inconsistent_destination_point_dimenstions: bool = (
+        len(set([len(p) for p in destination_points])) == 1
+    )
+
+    if too_few_source_points:
+        raise ValueError(
+            f"Too few points in source set (need at least 4, had {len(source_points)})."
+        )
+    if too_few_destination_points:
+        raise ValueError(
+            f"Too few points in destination set (need at least 4, had {len(destination_points)})."
+        )
+    if unequal_point_sets:
+        err_msg: str = "Point sets were unequal in length. "
+        err_msg += f"(length of source: {len(source_points)}, "
+        err_msg += f"length of destination: {len(destination_points)})"
+        raise ValueError(err_msg)
+    if inconsistent_source_point_dimenstions:
+        err_msg: str = "Source point set had inconsistent dimensions. "
+        err_msg += f"(Included dimensions: {len(set([len(p) for p in source_points]))})"
+        raise ValueError(err_msg)
+    if inconsistent_destination_point_dimenstions:
+        err_msg: str = "Destination point set had inconsistent dimensions. "
+        err_msg += f"(Included dimensions: {len(set([len(p) for p in destination_points]))})"
+        raise ValueError(err_msg)
+    
+    return findHomography(source_points, destination_points)
 
 
 def transform_point(

--- a/ChartExtractor/point_registration/homography.py
+++ b/ChartExtractor/point_registration/homography.py
@@ -1,0 +1,56 @@
+"""Module for remapping points using a homography transform.
+
+This module exposes a two functions, (1) find_homography, which is a thin wrapper around opencv's
+findHomography function so that cv2 doesn't have to be imported where this is used, and
+(2) transform_point, which takes a point and a homography matrix and transforms the point.
+
+Functions:
+    find_homography(source_points: List[Tuple[int, int]], destination_points: List[Tuple[int, int]])
+        -> np.ndarray:
+        Computes the homography transformation that maps the source_points array to the
+        destination_points array. A thin wrapper around opencv's findHomography function.
+    transform_point(point: Tuple[int, int], homography_matrix: np.ndarray) -> Tuple[int, int]:
+        Remaps a single point using the homography matrix.
+"""
+
+import cv2
+import numpy as np
+from typing import List, Tuple
+
+
+def find_homography(
+    source_points: List[Tuple[int, int]],
+    destination_points: List[Tuple[int, int]],
+) -> np.ndarray:
+    """A thin wrapper around opencv's findHomography function.
+    
+    Args:
+        source_points (List[Tuple[int, int]]):
+            The points to move to match to destination points.
+        destination_points (List[Tuple[int, int]]):
+            The points that the source points are moved to match.
+
+    Returns:
+        A numpy ndarray containing the homography matrix which can be used with transform_point
+        to transform points according to the transformation that remaps the source points to the
+        destination points.
+    """
+    pass
+
+
+def transform_point(
+    point: Tuple[int, int],
+    homography_matrix: np.ndarray,
+) -> Tuple[int, int]:
+    """Remaps a single point using the homography matrix.
+    
+    Args:
+        point (Tuple[int, int]):
+            The point to remap.
+        homography_matrix (np.ndarray):
+            A homography matrix.
+
+    Returns:
+        A point which has been transformed by the homography.
+    """
+    pass

--- a/ChartExtractor/point_registration/homography.py
+++ b/ChartExtractor/point_registration/homography.py
@@ -40,10 +40,8 @@ def find_homography(
     too_few_source_points: bool = len(source_points) < 4
     too_few_destination_points: bool = len(destination_points) < 4
     unequal_point_sets: bool = len(source_points) != len(destination_points)
-    inconsistent_source_point_dimenstions: bool = len(set([len(p) for p in source_points])) == 1
-    inconsistent_destination_point_dimenstions: bool = (
-        len(set([len(p) for p in destination_points])) == 1
-    )
+    source_points_not_two_dimensional: bool = set([len(p) for p in source_points]) == {2}
+    destination_points_not_two_dimensional: bool = set([len(p) for p in destination_points]) == {2}
 
     if too_few_source_points:
         raise ValueError(
@@ -58,13 +56,13 @@ def find_homography(
         err_msg += f"(length of source: {len(source_points)}, "
         err_msg += f"length of destination: {len(destination_points)})"
         raise ValueError(err_msg)
-    if inconsistent_source_point_dimenstions:
-        err_msg: str = "Source point set had inconsistent dimensions. "
-        err_msg += f"(Included dimensions: {len(set([len(p) for p in source_points]))})"
+    if source_points_not_two_dimensional:
+        err_msg: str = "Source point set contains non two dimensional points. "
+        err_msg += f"(Included dimensions: {set([len(p) for p in source_points])})"
         raise ValueError(err_msg)
-    if inconsistent_destination_point_dimenstions:
-        err_msg: str = "Destination point set had inconsistent dimensions. "
-        err_msg += f"(Included dimensions: {len(set([len(p) for p in destination_points]))})"
+    if destination_points_not_two_dimensional:
+        err_msg: str = "Destination point set contains non two dimensional points. "
+        err_msg += f"(Included dimensions: {set([len(p) for p in destination_points])})"
         raise ValueError(err_msg)
     
     return findHomography(source_points, destination_points)


### PR DESCRIPTION
Add a new module: `point_registration` which will contain point set registration code.
Added the homography.py file to the point_registration module which will use the homography transformation to remap singular points.