### PR TITLE
Refactor extraction module

### DIFF
--- a/ChartExtractor/extraction/extraction.py
+++ b/ChartExtractor/extraction/extraction.py
@@ -1,11 +1,12 @@
 """Consolidates all the functionality for extracting data from charts into one function."""
 
 # Built-in imports
-from functools import partial
+from functools import partial, reduce
+from operator import concat
 import os
 from pathlib import Path
 from PIL import Image
-from typing import Dict, List, Literal, Tuple
+from typing import Any, Dict, List, Literal, Tuple
 
 # Internal Imports
 from ..extraction.blood_pressure_and_heart_rate import (
@@ -40,6 +41,13 @@ from ..label_clustering.isolate_labels import (
 from ..object_detection_models.onnx_yolov11_detection import OnnxYolov11Detection
 from ..object_detection_models.onnx_yolov11_pose_single import OnnxYolov11PoseSingle
 from ..object_detection_models.object_detection_model import ObjectDetectionModel
+from ..point_registration.homography import (
+    find_homography,
+    transform_point,
+    transform_box,
+    transform_keypoint,
+)
+from ..utilities.annotations import BoundingBox, Keypoint
 from ..utilities.detections import Detection
 from ..utilities.detection_reassembly import (
     untile_detections,
@@ -49,6 +57,9 @@ from ..utilities.detection_reassembly import (
 from ..utilities.image_conversion import pil_to_cv2
 from ..utilities.read_config import read_config
 from ..utilities.tiling import tile_image
+
+# External Imports
+import numpy as np
 
 
 PATH_TO_DATA: Path = (Path(os.path.dirname(__file__)) / ".." / ".." / "data").resolve()
@@ -109,6 +120,377 @@ def digitize_sheet(intraop_image: Image.Image, preop_postop_image: Image.Image) 
     data.update(digitize_intraop_record(intraop_image))
     data.update(digitize_preop_postop_record(preop_postop_image))
     return data
+
+
+def run_models(
+    intraop_image: Image.Image,
+    preop_postop_image: Image.Image
+) -> Dict[str, List[Detection]]:
+    """Runs all the models and puts their output into a dictionary.
+    
+    Args:
+        `intraop_image` (Image.Image):
+            A smartphone photograph of the intraoperative side of the paper
+            anesthesia record.
+        `preop_postop_image` (Image.Image):
+            A smartphone photograph of the preoperative/postoperative side of the
+            paper anesthesia record.
+    
+    Returns:
+        A dictionary containing all the detections on both images. The structure of the dictionary
+        is set up as:
+        {
+            "intraoperative": {
+                "landmarks": [...],
+                "numbers": [...],
+                "checkboxes": [...],
+                "systolic": [...],
+                "diastoic": [...],
+                "heart_rate": [...],
+            },
+            "preoperative_postoperative": {
+                "landmarks": [...],
+                "numbers": [...],
+                "checkboxes": [...],
+            }
+        }
+    """
+    detections_dict: Dict[str, List[Detection]] = dict()
+    detections_dict["intraoperative"] = run_intraoperative_models(intraop_image)
+    detections_dict["preoperative_postoperative"] = (
+        run_preoperative_postoperative_models(preop_postop_image)
+    )
+    return detections_dict
+
+
+def run_intraoperative_models(intraop_image: Image.Image) -> Dict[str, List[Detection]]:
+    """Runs all the models on the preoperative/postoperative image and outputs to a dictionary.
+    
+    Args:
+        `intraop_image` (Image.Image):
+            A smartphone photograph of the intraoperative side of the paper anesthesia record.
+    
+    Returns:
+        A dictionary containing all of the detections on the intraoperative image.
+        The structure of the dictionary is set up as:
+        {
+            "landmarks": [...],
+            "numbers": [...],
+            "checkboxes": [...],
+            "systolic": [...],
+            "diastoic": [...],
+            "heart_rate": [...],
+        }
+    """
+    detections_dict: Dict[str, List[Detection]] = dict()
+
+    # landmarks
+    landmark_tile_size: int = compute_tile_size(
+        MODEL_CONFIG["intraoperative_document_landmarks"],
+        intraop_image.size
+    )
+    detections_dict["landmarks"] = detect_objects_using_tiling(
+        intraop_image,
+        INTRAOP_DOC_MODEL,
+        landmark_tile_size,
+        landmark_tile_size,
+        MODEL_CONFIG["intraoperative_document_landmarks"]["horz_overlap_proportion"],
+        MODEL_CONFIG["intraoperative_document_landmarks"]["vert_overlap_proportion"],
+    )
+
+    # numbers
+    digit_tile_size: int = compute_tile_size(MODEL_CONFIG["numbers"], intraop_image.size)
+    detections_dict["numbers"] = detect_objects_using_tiling(
+        intraop_image,
+        NUMBERS_MODEL,
+        digit_tile_size,
+        digit_tile_size,
+        MODEL_CONFIG["numbers"]["horz_overlap_proportion"],
+        MODEL_CONFIG["numbers"]["vert_overlap_proportion"],
+    )
+
+    # checkboxes
+    tile_size = compute_tile_size(MODEL_CONFIG["checkboxes"], intraop_image.size)
+    detections_dict["checkboxes"] = detect_objects_using_tiling(
+        intraop_image,
+        CHECKBOXES_MODEL,
+        tile_size,
+        tile_size,
+        MODEL_CONFIG["checkboxes"]["horz_overlap_proportion"],
+        MODEL_CONFIG["checkboxes"]["vert_overlap_proportion"],
+        nms_threshold=0.8
+    )
+
+    # systolic
+    sys_tile_size: int = compute_tile_size(MODEL_CONFIG["systolic"], intraop_image.size)
+    detections_dict["systolic"] = detect_objects_using_tiling(
+        intraop_image.copy(),
+        SYSTOLIC_MODEL,
+        sys_tile_size,
+        sys_tile_size,
+        MODEL_CONFIG["systolic"]["horz_overlap_proportion"],
+        MODEL_CONFIG["systolic"]["vert_overlap_proportion"],
+    )
+    
+    # diastolic
+    dia_tile_size: int = compute_tile_size(MODEL_CONFIG["diastolic"], intraop_image.size)
+    detections_dict["diastolic"] = detect_objects_using_tiling(
+        intraop_image.copy(),
+        DIASTOLIC_MODEL,
+        dia_tile_size,
+        dia_tile_size,
+        MODEL_CONFIG["diastolic"]["horz_overlap_proportion"],
+        MODEL_CONFIG["diastolic"]["vert_overlap_proportion"],
+    )
+    
+    # heart rate
+    hr_tile_size: int = compute_tile_size(MODEL_CONFIG["heart_rate"], intraop_image.size)
+    detections_dict["heart_rate"] = detect_objects_using_tiling(
+        intraop_image.copy(),
+        HEART_RATE_MODEL,
+        hr_tile_size,
+        hr_tile_size,
+        MODEL_CONFIG["heart_rate"]["horz_overlap_proportion"],
+        MODEL_CONFIG["heart_rate"]["vert_overlap_proportion"],
+    )
+
+    return detections_dict
+
+
+def run_preoperative_postoperative_models(
+    preop_postop_image: Image.Image
+) -> Dict[str, List[Detection]]:
+    """Runs all the models on the preoperative/postoperative image and outputs to a dictionary.
+    
+    Args:
+        `preop_postop_image` (Image.Image):
+            A smartphone photograph of the preoperative/postoperative side of the
+            paper anesthesia record.
+    
+    Returns:
+        A dictionary containing all of the detections on the preoperative/postoperative image.
+        The structure of the dictionary is set up as:
+        {
+            "landmarks": [...],
+            "numbers": [...],
+            "checkboxes": [...],
+        }
+    """
+    detections_dict: Dict[str, List[Detection]] = dict()
+    
+    # landmarks
+    landmark_tile_size: int = compute_tile_size(
+        MODEL_CONFIG["preop_postop_document_landmarks"],
+        preop_postop_image.size,
+    )
+    detections_dict["landmarks"] = detect_objects_using_tiling(
+        preop_postop_image,
+        PREOP_POSTOP_DOC_MODEL,
+        landmark_tile_size,
+        landmark_tile_size,
+        MODEL_CONFIG["preop_postop_document_landmarks"]["horz_overlap_proportion"],
+        MODEL_CONFIG["preop_postop_document_landmarks"]["vert_overlap_proportion"],
+    )
+
+    # numbers
+    digit_tile_size: int = compute_tile_size(MODEL_CONFIG["numbers"], preop_postop_image.size)
+    detections_dict["numbers"] = detect_objects_using_tiling(
+        preop_postop_image,
+        NUMBERS_MODEL,
+        digit_tile_size,
+        digit_tile_size,
+        MODEL_CONFIG["numbers"]["horz_overlap_proportion"],
+        MODEL_CONFIG["numbers"]["vert_overlap_proportion"],
+    )
+
+    # checkboxes
+    tile_size = compute_tile_size(MODEL_CONFIG["checkboxes"], preop_postop_image.size)
+    detections_dict["checkboxes"] = detect_objects_using_tiling(
+        preop_postop_image,
+        CHECKBOXES_MODEL,
+        tile_size,
+        tile_size,
+        MODEL_CONFIG["checkboxes"]["horz_overlap_proportion"],
+        MODEL_CONFIG["checkboxes"]["vert_overlap_proportion"],
+        nms_threshold=0.8
+    )
+
+    return detections_dict
+
+
+def assign_meaning_to_detections(detections_dict: Dict[str, List[Detection]]) -> Dict[str, Any]:
+    """Imputes values to the detections to get the data encoded by the provider onto the chart.
+    
+    Examples of assigning meaning include getting mmHg and timestamp values for blood pressure
+    markers, assigning meaning to checked/unchecked checkbox detections, etc.
+
+    Args:
+        detections_dict (Dict[str, List[Detection]]):
+            The detections from all models on both sides of the chart. Dictionary must match the
+            template that is output by run_models.
+
+    Returns:
+        A dictionary with data that approximately matches the encoded meaning that the medical
+        provider wrote onto the chart.
+    """
+    data: Dict[str, Any] = dict()
+    data["intraoperative"] = assign_meaning_to_intraoperative_detections(
+        detections_dict["intraoperative"]
+    )
+    data["preoperative_postoperative"] = assign_meaning_to_preoperative_postoperative_detections(
+        detections_dict["preoperative_postoperative"]
+    )
+    return data
+
+
+def assign_meaning_to_intraoperative_detections(
+    intraop_detections_dict: Dict[str, List[Detection]],
+    image_size: Tuple[int, int] = (3300, 2550)
+) -> Dict[str, Any]:
+    """Imputes values to the detections on the intraoperative side of the chart.
+    
+    Args:
+        intraop_detections_dict (Dict[str, List[Detection]]):
+            The detections from all models on the intraoperative side of the chart.
+            Must match the template that is output by run_intraoperative_models.
+        image_size (Tuple[int, int]):
+            The size of the image.
+
+    Returns:
+        A dictionary with data that approximately matches the encoded meaning that the medical
+        provider wrote onto the intraoperative side of the chart.
+    """
+    h = create_intraoperative_homography_matrix(intraop_detections_dict["landmarks"])
+    corrected_detections_dict: Dict[str, List[Detection]] = dict()
+    for (key, detections) in intraop_detections_dict.items():
+        if len(detections) == 0:
+            continue
+        remap_func = (
+            transform_box
+            if isinstance(detections[0].annotation, BoundingBox)
+            else transform_keypoint
+        )
+        corrected_detections_dict[key] = [
+            Detection(remap_func(det.annotation, h), det.confidence) for det in detections
+        ]
+    
+    extracted_data: Dict[str, Any] = dict()
+
+    # extract drug code and surgical timing
+    extracted_data["codes"] = extract_drug_codes(
+        corrected_detections_dict["numbers"],
+        *image_size
+    )
+    extracted_data["timing"] = extract_surgical_timing(
+        corrected_detections_dict["numbers"],
+        *image_size
+    )
+    extracted_data["ett_size"] = extract_ett_size(
+        corrected_detections_dict["numbers"],
+        *image_size
+    )
+
+    # extract inhaled volatile drugs
+    time_boxes, mmhg_boxes = isolate_blood_pressure_legend_bounding_boxes(
+        [det.annotation for det in corrected_detections_dict["landmarks"]], *image_size
+    )
+    time_clusters: List[Cluster] = cluster_boxes(
+        time_boxes, cluster_kmeans, "mins", possible_nclusters=[40, 41, 42]
+    )
+    mmhg_clusters: List[Cluster] = cluster_boxes(
+        mmhg_boxes, cluster_kmeans, "mmhg", possible_nclusters=[18, 19, 20]
+    )
+
+    legend_locations: Dict[str, Tuple[float, float]] = find_legend_locations(
+        time_clusters + mmhg_clusters
+    )
+    extracted_data["inhaled_volatile"] = extract_inhaled_volatile(
+        corrected_detections_dict["numbers"],
+        legend_locations,
+        corrected_detections_dict["landmarks"]
+    )
+
+    # extract bp and hr
+    bp_and_hr_dets = reduce(
+        concat,
+        [
+            corrected_detections_dict["systolic"],
+            corrected_detections_dict["diastolic"],
+            corrected_detections_dict["heart_rate"],
+        ],
+        list()
+    )
+    
+    extracted_data["bp_and_hr"] = extract_heart_rate_and_blood_pressure(
+        bp_and_hr_dets,
+        time_clusters,
+        mmhg_clusters,
+    )
+
+    # extract physiological indicators
+    extracted_data["physiological_indicators"] = extract_physiological_indicators(
+        corrected_detections_dict["numbers"],
+        legend_locations,
+        corrected_detections_dict["landmarks"],
+        *image_size
+    )
+
+    # extract checkboxes
+    extracted_data["checkboxes"] = extract_checkboxes(
+        corrected_detections_dict["checkboxes"],
+        "intraoperative",
+        image_size[0],
+        image_size[1],
+    )
+
+    return extracted_data
+
+
+def assign_meaning_to_preoperative_postoperative_detections(
+    preop_postop_detections_dict: Dict[str, List[Detection]],
+    image_size: Tuple[int, int] = (3300, 2550)
+) -> Dict[str, Any]:
+    """Imputes values to the detections on the preoperative/postoperative side of the chart.
+    
+    Args:
+        intraop_detections_dict (Dict[str, List[Detection]]):
+            The detections from all models on the preoperative/postoperative side of the chart.
+            Must match the template that is output by run_intraoperative_models.
+
+    Returns:
+        A dictionary with data that approximately matches the encoded meaning that the medical
+        provider wrote onto the preoperative/postoperative side of the chart.
+    """
+    h = create_preoperative_postoperative_homography_matrix(
+        preop_postop_detections_dict["landmarks"]
+    )
+    corrected_detections_dict: Dict[str, List[Detection]] = dict()
+    for (key, detections) in preop_postop_detections_dict.items():
+        if len(detections) == 0:
+            continue
+        remap_func = (
+            transform_box
+            if isinstance(detections[0].annotation, BoundingBox)
+            else transform_keypoint
+        )
+        corrected_detections_dict[key] = [
+            Detection(remap_func(det.annotation, h), det.confidence) for det in detections
+        ]
+
+    extracted_data: Dict[str, Any] = dict()
+
+    extracted_data.update(
+        extract_preop_postop_digit_data(
+            corrected_detections_dict["numbers"], 
+            *image_size
+        )
+    )
+    extracted_data["checkboxes"] = extract_checkboxes(
+        corrected_detections_dict["checkboxes"],
+        "preoperative",
+        *image_size
+    )
+    return extracted_data
 
 
 def digitize_intraop_record(image: Image.Image) -> Dict:
@@ -177,6 +559,7 @@ def digitize_intraop_record(image: Image.Image) -> Dict:
     legend_locations: Dict[str, Tuple[float, float]] = find_legend_locations(
         time_clusters + mmhg_clusters
     )
+
     inhaled_volatile: Dict = {
         "inhaled_volatile": extract_inhaled_volatile(
             digit_detections, legend_locations, document_landmark_detections
@@ -255,6 +638,95 @@ def digitize_preop_postop_record(image: Image.Image) -> Dict:
         "preoperative_checkboxes": make_preop_postop_checkbox_detections(image)
     }
     return combine_dictionaries([digit_data, checkbox_data])
+
+
+def create_homography_matrix(
+    landmark_detections: List[Detection],
+    corner_landmark_names: List[str],
+    destination_landmarks: List[BoundingBox]
+) -> np.ndarray:
+    """Creates a homography matrix from the corner landmarks.
+    
+    Args:
+        landmark_detections (List[Detection]):
+            The list of detected landmarks.
+        corner_landmark_names (List[str]):
+            The list of names that match categories from the landmark detections.
+        destination_landmarks (List[BoundingBox]):
+            The landmark locations on the perfect, scanned image.
+
+    Returns:
+        A homography matrix that linearly transforms points from the original image to the
+        scanned, perfect image.
+    """
+    dest_points = [
+        bb.center
+        for bb in sorted(
+            list(filter(lambda x: x.category in corner_landmark_names, destination_landmarks)),
+            key=lambda bb: bb.category,
+        )
+    ]
+    src_points = [
+        bb.annotation.center
+        for bb in sorted(
+            list(
+                filter(
+                    lambda x: x.annotation.category in corner_landmark_names,
+                    landmark_detections,
+                )
+            ),
+            key=lambda bb: bb.annotation.category,
+        )
+    ]
+    return find_homography(src_points, dest_points)
+
+
+def create_intraoperative_homography_matrix(landmark_detections: List[Detection]) -> np.ndarray:
+    """Creates a homography matrix for the intraoperative side of the chart.
+    
+    Args:
+        landmark_detections (List[Detection]):
+            The list of detected landmarks.
+
+    Returns:
+        A homography matrix that linearly transforms points from the original image to the
+        scanned, perfect image.
+    """
+    corner_landmark_names: List[str] = [
+        "anesthesia_start",
+        "safety_checklist",
+        "lateral",
+        "units",
+    ]
+    dst_landmarks: List[BoundingBox] = label_studio_to_bboxes(
+        str(PATH_TO_DATA / "intraop_document_landmarks.json")
+    )["unified_intraoperative_preoperative_flowsheet_v1_1_front.png"]
+    return create_homography_matrix(landmark_detections, corner_landmark_names, dst_landmarks)
+
+
+def create_preoperative_postoperative_homography_matrix(
+    landmark_detections: List[Detection]
+) -> np.ndarray:
+    """Creates a homography matrix for the intraoperative side of the chart.
+    
+    Args:
+        landmark_detections (List[Detection]):
+            The list of detected landmarks.
+
+    Returns:
+        A homography matrix that linearly transforms points from the original image to the
+        scanned, perfect image.
+    """
+    corner_landmark_names: List[str] = [
+        "patient_profile",
+        "weight",
+        "signature",
+        "disposition",
+    ]
+    dst_landmarks: List[BoundingBox] = label_studio_to_bboxes(
+        str(PATH_TO_DATA / "preoperative_document_landmarks.json")
+    )["unified_intraoperative_preoperative_flowsheet_v1_1_back.png"]
+    return create_homography_matrix(landmark_detections, corner_landmark_names, dst_landmarks)
 
 
 def homography_intraoperative_chart(

--- a/ChartExtractor/extraction/extraction_utilities.py
+++ b/ChartExtractor/extraction/extraction_utilities.py
@@ -5,7 +5,7 @@ from functools import reduce
 import json
 from pathlib import Path
 from PIL import Image
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 # External imports
 import numpy as np
@@ -98,33 +98,59 @@ def compute_digit_distances_to_centroids(
     return closest_boxes
 
 
-def detect_numbers(
+def detect_objects_using_tiling(
     image: Image.Image,
     detection_model: ObjectDetectionModel,
     slice_width: int,
     slice_height: int,
     horizontal_overlap_ratio: float,
     vertical_overlap_ratio: float,
-    conf: float = 0.5,
+    minimum_confidence: float = 0.5,
+    nms_threshold: float = 0.5,
+    overlap_comparator: Callable[[Detection, Detection], float] = intersection_over_minimum,
+    sorting_fn: Callable[[Detection], float] = lambda det: det.annotation.area * det.confidence,
 ) -> List[Detection]:
-    """Detects handwritten digits on an image.
+    """Detects objects, especially small ones, using image tiling.
+
+    Splits an image up into smaller tiles, runs the model on each tile, then untiles the detections
+    and performs non-maximum suppression on the result.
 
     Args:
         `image` (Image.Image):
             The image to detect on.
         `detection_model` (ObjectDetectionModel):
-            The digit detection model.
+            The detection model to use. Can be any object that implements the ObjectDetectionModel
+            protocol.
         `slice_height` (int):
             The height of each slice.
         `slice_width` (int):
             The width of each slice.
         `horizontal_overlap_ratio` (float):
             The amount of left-right overlap between slices.
+            (Ex: 0.2 results in 20% of a tile overlapping with the tile on the left and 20%
+            overlapping on the right.)
         `vertical_overlap_ratio` (float):
             The amount of top-bottom overlap between slices.
-
+            (Ex: 0.2 results in 20% of a tile overlapping with the tile on the top and 20%
+            overlapping on the bottom.)
+        `minimum_confidence` (float):
+            The minimum confidence level. Any detection with a confidence score below this will not
+            be added to the returned detections. Defaults to 0.5.
+        `nms_threshold` (float):
+            The threshold above which nms registers a 'match', and deletes all but the first
+            detection in a 'group'. A group is determined by the sorting_fn. Defaults to 0.5.
+        `overlap_comparator` (float):
+            The function that determines how much two detections overlap. Defaults to the
+            intersection of the detections divided by the minimum of the two detection's areas.
+            This default prevents partial detections from remaining inside the full detection.
+        `sorting_fn` (Callable[[Detection], float]):
+            The function that applies a 'score' to each detection to determine which has priority
+            when NMS deletes detections. Only the detection with the highest score in a group
+            remains. Defaults to the detection's confidence times its area.
+    
     Returns:
-        A list of handwritten digit detections on the image.
+        A list of detections showing objects on the image that the object detection model was
+        trained to identify.
     """
     image_tiles: List[List[Image.Image]] = tile_image(
         image,
@@ -134,7 +160,7 @@ def detect_numbers(
         vertical_overlap_ratio,
     )
     detections: List[List[List[Detection]]] = [
-        [detection_model(pil_to_cv2(tile), confidence=conf)[0] for tile in row]
+        [detection_model(pil_to_cv2(tile), confidence=minimum_confidence)[0] for tile in row]
         for row in image_tiles
     ]
     detections: List[Detection] = untile_detections(
@@ -146,9 +172,9 @@ def detect_numbers(
     )
     detections: List[Detection] = non_maximum_suppression(
         detections=detections,
-        threshold=0.5,
-        overlap_comparator=intersection_over_minimum,
-        sorting_fn=lambda det: det.annotation.area * det.confidence,
+        threshold=nms_threshold,
+        overlap_comparator=overlap_comparator,
+        sorting_fn=sorting_fn,
     )
     return detections
 
@@ -236,7 +262,7 @@ def read_detections_from_json(
 
 
 def write_detections_to_json(
-    filepath: Path
+    filepath: Path,
     detections: List[Detection]
 ) -> bool:
     """Serializes detections to a json file.

--- a/ChartExtractor/point_registration/homography.py
+++ b/ChartExtractor/point_registration/homography.py
@@ -1,0 +1,92 @@
+"""Module for remapping points using a homography transform.
+
+This module exposes two functions, (1) find_homography, which is a thin wrapper around opencv's
+findHomography function that restricts the original function's usage to only 2d points, and
+provides more robust error messages for this libraries usage, and (2) transform_point, which takes 
+a point and a homography matrix and transforms the point.
+
+Functions:
+    find_homography(source_points: List[Tuple[int, int]], destination_points: List[Tuple[int, int]])
+        -> np.ndarray:
+        Computes the homography transformation that maps the source_points array to the
+        destination_points array. A thin wrapper around opencv's findHomography function.
+    transform_point(point: Tuple[int, int], homography_matrix: np.ndarray) -> Tuple[int, int]:
+        Remaps a single point using the homography matrix.
+"""
+
+import cv2
+import numpy as np
+from typing import List, Tuple
+
+
+def find_homography(
+    source_points: List[Tuple[int, int]],
+    destination_points: List[Tuple[int, int]],
+) -> np.ndarray:
+    """A thin wrapper around opencv's findHomography function.
+
+    Provides some additional checks and more informative errors.
+    
+    Args:
+        source_points (List[Tuple[int, int]]):
+            The points to move to match to destination points.
+        destination_points (List[Tuple[int, int]]):
+            The points that the source points are moved to match.
+
+    Returns:
+        A numpy ndarray containing the homography matrix which can be used with transform_point
+        to transform points according to the transformation that remaps the source points to the
+        destination points.
+    """
+    too_few_source_points: bool = len(source_points) < 4
+    too_few_destination_points: bool = len(destination_points) < 4
+    unequal_point_sets: bool = len(source_points) != len(destination_points)
+    source_points_not_two_dimensional: bool = set([len(p) for p in source_points]) == {2}
+    destination_points_not_two_dimensional: bool = set([len(p) for p in destination_points]) == {2}
+
+    if too_few_source_points:
+        raise ValueError(
+            f"Too few points in source set (need at least 4, had {len(source_points)})."
+        )
+    if too_few_destination_points:
+        raise ValueError(
+            f"Too few points in destination set (need at least 4, had {len(destination_points)})."
+        )
+    if unequal_point_sets:
+        err_msg: str = "Point sets were unequal in length. "
+        err_msg += f"(length of source: {len(source_points)}, "
+        err_msg += f"length of destination: {len(destination_points)})"
+        raise ValueError(err_msg)
+    if source_points_not_two_dimensional:
+        err_msg: str = "Source point set contains non two dimensional points. "
+        err_msg += f"(Included dimensions: {set([len(p) for p in source_points])})"
+        raise ValueError(err_msg)
+    if destination_points_not_two_dimensional:
+        err_msg: str = "Destination point set contains non two dimensional points. "
+        err_msg += f"(Included dimensions: {set([len(p) for p in destination_points])})"
+        raise ValueError(err_msg)
+    
+    return findHomography(source_points, destination_points)
+
+
+def transform_point(
+    point: Tuple[int, int],
+    homography_matrix: np.ndarray,
+) -> Tuple[int, int]:
+    """Remaps a single point using the homography matrix.
+    
+    Args:
+        point (Tuple[int, int]):
+            The point to remap.
+        homography_matrix (np.ndarray):
+            A homography matrix.
+
+    Returns:
+        A point which has been transformed by the homography.
+    """
+    if len(point) != 2:
+        raise ValueError(f"Point is not two dimensional: {point}.")
+    
+    remapped_point = homography_matrix.dot(np.array([point[0], point[1], 1]))
+    remapped_point /= remapped_point[2]
+    return (remapped_point[0], remapped_point[1])

--- a/ChartExtractor/point_registration/homography.py
+++ b/ChartExtractor/point_registration/homography.py
@@ -14,9 +14,15 @@ Functions:
         Remaps a single point using the homography matrix.
 """
 
-import cv2
-import numpy as np
+# Built-in imports
 from typing import List, Tuple
+
+# Internal imports
+from ..utilities.annotations import BoundingBox, Keypoint, Point
+
+# External imports
+from cv2 import findHomography
+import numpy as np
 
 
 def find_homography(
@@ -41,8 +47,8 @@ def find_homography(
     too_few_source_points: bool = len(source_points) < 4
     too_few_destination_points: bool = len(destination_points) < 4
     unequal_point_sets: bool = len(source_points) != len(destination_points)
-    source_points_not_two_dimensional: bool = set([len(p) for p in source_points]) == {2}
-    destination_points_not_two_dimensional: bool = set([len(p) for p in destination_points]) == {2}
+    source_points_not_two_dimensional: bool = set([len(p) for p in source_points]) != {2}
+    destination_points_not_two_dimensional: bool = set([len(p) for p in destination_points]) != {2}
 
     if too_few_source_points:
         raise ValueError(
@@ -66,13 +72,10 @@ def find_homography(
         err_msg += f"(Included dimensions: {set([len(p) for p in destination_points])})"
         raise ValueError(err_msg)
     
-    return findHomography(source_points, destination_points)
+    return findHomography(np.array(source_points), np.array(destination_points))[0]
 
 
-def transform_point(
-    point: Tuple[int, int],
-    homography_matrix: np.ndarray,
-) -> Tuple[int, int]:
+def transform_point(point: Tuple[int, int], homography_matrix: np.ndarray) -> Tuple[int, int]:
     """Remaps a single point using the homography matrix.
     
     Args:
@@ -90,3 +93,55 @@ def transform_point(
     remapped_point = homography_matrix.dot(np.array([point[0], point[1], 1]))
     remapped_point /= remapped_point[2]
     return (remapped_point[0], remapped_point[1])
+
+
+def transform_box(box: BoundingBox, homography_matrix: np.ndarray) -> BoundingBox:
+    """Remaps a BoundingBox using the homography matrix.
+
+    Args:
+        box (BoundingBox):
+            The bounding box to remap.
+        homography_matrix (np.ndarray):
+            A homography matrix
+
+    Returns:
+        A BoundingBox that has been transformed by the homography.
+    """
+    remapped_top_left: Tuple[float, float] = transform_point((box.left, box.top), homography_matrix)
+    remapped_top_right: Tuple[float, float] = transform_point(
+        (box.right, box.top),
+        homography_matrix,
+    )
+    remapped_bottom_left: Tuple[float, float] = transform_point(
+        (box.left, box.bottom),
+        homography_matrix,
+    )
+    remapped_bottom_right: Tuple[float, float] = transform_point(
+        (box.right, box.bottom),
+        homography_matrix,
+    )
+    
+    left = min(remapped_top_left[0], remapped_bottom_left[0])
+    top = min(remapped_top_left[1], remapped_top_right[1])
+    right = max(remapped_top_right[0], remapped_bottom_right[0])
+    bottom = max(remapped_bottom_left[1], remapped_bottom_right[1])
+
+    return BoundingBox(box.category, left, top, right, bottom)
+
+
+def transform_keypoint(keypoint: Keypoint, homography_matrix: np.ndarray) -> Keypoint:
+    """Remaps a Keypoint using the homography matrix.
+    
+    Args:
+        keypoint (Keypoint):
+            The keypoint to remap.
+        homography_matrix (np.ndarray):
+            A homography matrix
+
+    Returns:
+        A Keypoint that has been transformed by the homography.
+    """
+    point = (keypoint.keypoint.x, keypoint.keypoint.y)
+    remapped_point = transform_point(point, homography_matrix)
+    remapped_box = transform_box(keypoint.bounding_box, homography_matrix)
+    return Keypoint(Point(*remapped_point), remapped_box, do_keypoint_validation=False)


### PR DESCRIPTION
This pull request makes a few important changes to the extraction module.

1. The detection of objects is now isolated to a single function called `detect_objects_using_tiling`.
2. Functions have been added that detect all the objects on both the intraoperative and preoperative/postoperative sides of the image, and returns a dictionary of detections.
3. Functions have been added that assign meaning to the detections dictionary.
4. Adds a new module for point registration. When performing only meaning-assignment to detections, it is not necessary to do whole-image registration.

The functions that did both at the same time have been left alone, since they get slightly different results by detecting on the post-homography images.